### PR TITLE
update quint-connect to 2.1.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,7 +33,7 @@
     "@dnd/shared": "workspace:*",
     "@dnd/shared-algebras": "workspace:*",
     "@dnd/surface": "workspace:*",
-    "@firfi/quint-connect": "^2.0.0",
+    "@firfi/quint-connect": "catalog:",
     "@statelyai/graph": "^0.8.0",
     "@statelyai/inspect": "^0.4.0",
     "@tailwindcss/vite": "^4.1.18",

--- a/packages/battle-runtime/package.json
+++ b/packages/battle-runtime/package.json
@@ -85,7 +85,7 @@
     "effect": "^3.21.0"
   },
   "devDependencies": {
-    "@firfi/quint-connect": "^2.0.0",
+    "@firfi/quint-connect": "catalog:",
     "@types/node": "^22.10.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^5.9.3",

--- a/packages/character-battle-runtime/package.json
+++ b/packages/character-battle-runtime/package.json
@@ -24,7 +24,7 @@
     "effect": "^3.21.0"
   },
   "devDependencies": {
-    "@firfi/quint-connect": "^2.0.0",
+    "@firfi/quint-connect": "catalog:",
     "@types/node": "^22.10.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^5.9.3",

--- a/packages/character-creation-runtime/package.json
+++ b/packages/character-creation-runtime/package.json
@@ -25,7 +25,7 @@
     "effect": "^3.21.0"
   },
   "devDependencies": {
-    "@firfi/quint-connect": "^2.0.0",
+    "@firfi/quint-connect": "catalog:",
     "@types/node": "^22.10.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "fast-check": "3.23.2",

--- a/packages/character-sheet-runtime/package.json
+++ b/packages/character-sheet-runtime/package.json
@@ -24,7 +24,7 @@
     "effect": "^3.21.0"
   },
   "devDependencies": {
-    "@firfi/quint-connect": "^2.0.0",
+    "@firfi/quint-connect": "catalog:",
     "@types/node": "^22.10.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^5.9.3",

--- a/packages/shared-algebras/package.json
+++ b/packages/shared-algebras/package.json
@@ -49,7 +49,7 @@
     "effect": "^3.21.0"
   },
   "devDependencies": {
-    "@firfi/quint-connect": "^2.0.0",
+    "@firfi/quint-connect": "catalog:",
     "@types/node": "^22.10.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@firfi/quint-connect':
+      specifier: ^2.1.0
+      version: 2.1.0
+
 importers:
 
   .:
@@ -108,8 +114,8 @@ importers:
         specifier: workspace:*
         version: link:../surface
       '@firfi/quint-connect':
-        specifier: ^2.0.0
-        version: 2.0.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
+        specifier: 'catalog:'
+        version: 2.1.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       '@statelyai/graph':
         specifier: ^0.8.0
         version: 0.8.0(zod@4.3.6)
@@ -278,8 +284,8 @@ importers:
         version: 3.21.5
     devDependencies:
       '@firfi/quint-connect':
-        specifier: ^2.0.0
-        version: 2.0.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
+        specifier: 'catalog:'
+        version: 2.1.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.15
@@ -318,8 +324,8 @@ importers:
         version: 3.21.5
     devDependencies:
       '@firfi/quint-connect':
-        specifier: ^2.0.0
-        version: 2.0.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
+        specifier: 'catalog:'
+        version: 2.1.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.15
@@ -349,8 +355,8 @@ importers:
         version: 3.21.5
     devDependencies:
       '@firfi/quint-connect':
-        specifier: ^2.0.0
-        version: 2.0.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
+        specifier: 'catalog:'
+        version: 2.1.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.15
@@ -389,8 +395,8 @@ importers:
         version: 3.21.5
     devDependencies:
       '@firfi/quint-connect':
-        specifier: ^2.0.0
-        version: 2.0.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
+        specifier: 'catalog:'
+        version: 2.1.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.15
@@ -488,8 +494,8 @@ importers:
         version: 3.21.5
     devDependencies:
       '@firfi/quint-connect':
-        specifier: ^2.0.0
-        version: 2.0.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
+        specifier: 'catalog:'
+        version: 2.1.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.15
@@ -1035,8 +1041,9 @@ packages:
       zod:
         optional: true
 
-  '@firfi/quint-connect@2.0.0':
-    resolution: {integrity: sha512-Kml5pNE1BR+pLszrf1RGzfxqYDeoBBOjbdraSshsh87XMAGicq2DiGH/MRNKvt5nL8LjLJ/DI5KWZbn16lzE7Q==}
+  '@firfi/quint-connect@2.1.0':
+    resolution: {integrity: sha512-z/PyO5B0jdz7CI6BpRQoyyLGn1c+cOZO4xND684eq9nQ3t3eR26oB/sekfdSR2FlwF09XJtO9kYFbKT4Le3cNg==}
+    engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
       effect: ^3.0.0
@@ -5611,10 +5618,11 @@ snapshots:
       effect: 3.21.5
       zod: 4.3.6
 
-  '@firfi/quint-connect@2.0.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)':
+  '@firfi/quint-connect@2.1.0(effect@3.21.5)(vitest@3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(zod@4.3.6)':
     dependencies:
       '@firfi/itf-trace-parser': 0.1.2(effect@3.21.5)(zod@4.3.6)
       '@standard-schema/spec': 1.1.0
+      cross-spawn: 7.0.6
     optionalDependencies:
       effect: 3.21.5
       vitest: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ packages:
   - "packages/shared"
   - "packages/shared-algebras"
   - "packages/surface"
+catalog:
+  "@firfi/quint-connect": "^2.1.0"
 allowBuilds:
   '@parcel/watcher': true
   esbuild: true


### PR DESCRIPTION
## What changed

- update `@firfi/quint-connect` from 2.0.0 to the latest release, 2.1.0
- centralize the version in the pnpm workspace catalog
- point all six workspace consumers at the catalog and refresh `pnpm-lock.yaml`

## Why

Keep the model-based testing bridge current while making future connector upgrades a single-source version change.

## Impact

`@firfi/quint-connect` 2.1.0 requires Node 22 or newer. The repository Docker build and runtime images already use `node:22-alpine`.

## Validation

- `pnpm install --frozen-lockfile` passed after the catalog change
- initial `pnpm typecheck` passed across all nine packages
- package resolution and ESM import confirmed `@firfi/quint-connect` 2.1.0
- reviewer loop converged with no Standards or Spec findings
- `pnpm test` reached 86 failures in unchanged battle-runtime tests; a representative failure reproduced unchanged on `master`
- one focused, locked MBT generated and dispatched a trace through 2.1.0, then failed in unchanged D&D runtime admission logic

## Verification environment note

A second `pnpm typecheck` after the catalog-only refactor was not retried after its TypeScript child was SIGKILLed (PID 1439087), per repository emergency rules. At inspection time swap was effectively exhausted (16 GiB used), load average was 14.18, and no orphan verifier processes remained.
