### PR TITLE
Finish weapon attack override execution orchestration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@ echo "Checking QNT inventory..."
 pnpm check:qnt-inventory
 
 echo "Running lint-staged..."
-pnpm exec lint-staged --cwd packages/app --config packages/app/package.json
+pnpm exec lint-staged --config package.json
 
 echo "Running gitleaks to check for secrets..."
 gitleaks protect --verbose --staged

--- a/package.json
+++ b/package.json
@@ -71,5 +71,9 @@
     "onlyBuiltDependencies": [
       "esbuild"
     ]
+  },
+  "lint-staged": {
+    "*.{cjs,css,cts,html,js,jsx,json,md,mjs,mts,scss,ts,tsx}": "prettier --write",
+    "!(*pnpm-lock).{yaml,yml}": "prettier --write"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,12 +19,6 @@
     "circular": "madge --extensions ts,tsx --circular --exclude '.*\\.gen\\..*' src",
     "check-all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:coverage"
   },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
-    ]
-  },
   "dependencies": {
     "@dnd/battle-runtime": "workspace:*",
     "@dnd/character-creation-runtime": "workspace:*",

--- a/packages/battle-runtime/src/battle-reducer.ts
+++ b/packages/battle-runtime/src/battle-reducer.ts
@@ -480,6 +480,7 @@ export {
   interruptCheckpointFrame,
   interruptChoices,
   interruptDecisionHole,
+  interruptWindowProgress,
   interruptTriggerLabel,
   interruptedProcedureSubject,
   isReleaseGrappleSubject,
@@ -524,6 +525,7 @@ export {
   type FlySpeedGrantEndFallWitnessResult,
   type BattleRuntimeResolutionInput,
   type BattleRuntimeResolutionResult,
+  type BattleInterruptWindowProgress,
 } from "./battle-reducer/dispatcher.ts";
 
 export { zeroHpLifecycleIsTerminal } from "./battle-reducer/creature-state-leaves.ts";

--- a/packages/battle-runtime/src/battle-reducer/battle-runtime-protocol.ts
+++ b/packages/battle-runtime/src/battle-reducer/battle-runtime-protocol.ts
@@ -11,6 +11,10 @@ import {
   holeId,
   holeInstanceKey,
 } from "@dnd/shared-algebras/runtime-hole-algebra";
+export {
+  SPELL_CAST_REACTION_FACTS_HOLE_ID,
+  SPELL_CAST_REACTION_FACTS_HOLE_INSTANCE,
+} from "../procedure-execution/spell-cast-reaction-protocol.ts";
 import type { StandardActionKind } from "@dnd/shared/game-facts";
 import {
   difficultyClass,
@@ -55,12 +59,6 @@ export const INITIAL_TURN_RESOURCES = resetTurnActionEconomy({
 });
 export const ATTACK_TARGET_HOLE_ID = holeId("battle:attack:target");
 export const ATTACK_ROLL_HOLE_ID = holeId("battle:attack:roll");
-export const SPELL_CAST_REACTION_FACTS_HOLE_ID = holeId(
-  "battle:spell-cast:reaction-facts",
-);
-export const SPELL_CAST_REACTION_FACTS_HOLE_INSTANCE = holeInstanceKey(
-  "battle:spell-cast:reaction-facts",
-);
 export const ATTACK_DAMAGE_DISPOSITION_HOLE_ID = holeId(
   "battle:attack:damage-disposition",
 );

--- a/packages/battle-runtime/src/battle-reducer/dispatcher.ts
+++ b/packages/battle-runtime/src/battle-reducer/dispatcher.ts
@@ -6773,21 +6773,72 @@ export function unofferedEligibleResponders(
   );
 }
 
+export type BattleOpenedInterruptWindowResult = Extract<
+  BattleResolutionResult,
+  { readonly tag: "needsHoles" }
+> & {
+  readonly holes: readonly [BattleHole, ...BattleHole[]];
+};
+
+export type BattleInterruptWindowProgress =
+  | {
+      readonly tag: "checkpointPreparationFailed";
+      readonly result: Extract<
+        BattleResolutionResult,
+        { readonly tag: "invalid" }
+      >;
+    }
+  | { readonly tag: "interruptionsCleared" }
+  | {
+      readonly tag: "windowOpened";
+      readonly result: BattleOpenedInterruptWindowResult;
+    };
+
+export function interruptWindowProgress(
+  state: BattleState,
+  frame: BattleInterruptCheckpointInput,
+  handledInterruptTrigger: BattleInterruptTrigger | undefined,
+): BattleInterruptWindowProgress {
+  if (frame.trigger === handledInterruptTrigger) {
+    return { tag: "interruptionsCleared" };
+  }
+  const checkpointState = stateForOpeningInterruptCheckpoint(state, frame);
+  if (checkpointState === null) {
+    return {
+      tag: "checkpointPreparationFailed",
+      result: invalidResult(
+        state,
+        "staleSubject",
+        "The interrupt checkpoint could not reserve its pending spell resource.",
+      ),
+    };
+  }
+  const choices = nonEmptyInterruptChoices(
+    interruptChoices(checkpointState, frame),
+  );
+  return choices === null
+    ? { tag: "interruptionsCleared" }
+    : {
+        tag: "windowOpened",
+        result: openPreparedInterruptWindowWithChoices(
+          checkpointState,
+          frame,
+          choices,
+        ),
+      };
+}
+
 export function maybeOpenInterruptWindow(
   state: BattleState,
   frame: BattleInterruptCheckpointInput,
   handledInterruptTrigger: BattleInterruptTrigger | undefined,
 ): Extract<BattleResolutionResult, { readonly tag: "needsHoles" }> | null {
-  const checkpointState = stateForOpeningInterruptCheckpoint(state, frame);
-  if (checkpointState === null) {
-    return null;
-  }
-  return maybeOpenInterruptWindowWithChoices(
-    checkpointState,
+  const progress = interruptWindowProgress(
+    state,
     frame,
     handledInterruptTrigger,
-    interruptChoices(checkpointState, frame),
   );
+  return progress.tag === "windowOpened" ? progress.result : null;
 }
 
 export function maybeOpenSpellCastInterruptWindowWithTriggeredSpellChoices(
@@ -6795,17 +6846,16 @@ export function maybeOpenSpellCastInterruptWindowWithTriggeredSpellChoices(
   frame: BattleInterruptCheckpointInput,
   handledInterruptTrigger: BattleInterruptTrigger | undefined,
 ): Extract<BattleResolutionResult, { readonly tag: "needsHoles" }> | null {
-  const spellCastCheckpointState =
-    handledInterruptTrigger === undefined
-      ? stateForOpeningInterruptCheckpoint(state, frame)
-      : null;
-  return spellCastCheckpointState === null
+  if (frame.trigger === handledInterruptTrigger) {
+    return null;
+  }
+  const checkpointState = stateForOpeningInterruptCheckpoint(state, frame);
+  return checkpointState === null
     ? null
-    : maybeOpenInterruptWindowWithChoices(
-        spellCastCheckpointState,
+    : openPreparedInterruptWindowWithOptionalChoices(
+        checkpointState,
         frame,
-        handledInterruptTrigger,
-        triggeredReactionSpellChoices(spellCastCheckpointState, frame),
+        triggeredReactionSpellChoices(checkpointState, frame),
       );
 }
 
@@ -6822,9 +6872,49 @@ function maybeOpenInterruptWindowWithChoices(
   if (checkpointState === null) {
     return null;
   }
-  if (choices.length === 0) {
+  return openPreparedInterruptWindowWithOptionalChoices(
+    checkpointState,
+    frame,
+    choices,
+  );
+}
+
+function openPreparedInterruptWindowWithOptionalChoices(
+  checkpointState: BattleState,
+  frame: BattleInterruptCheckpointInput,
+  choices: readonly BattleInterruptProcedureChoice[],
+): Extract<BattleResolutionResult, { readonly tag: "needsHoles" }> | null {
+  const nonEmptyChoices = nonEmptyInterruptChoices(choices);
+  if (nonEmptyChoices === null) {
     return null;
   }
+  return openPreparedInterruptWindowWithChoices(
+    checkpointState,
+    frame,
+    nonEmptyChoices,
+  );
+}
+
+function nonEmptyInterruptChoices(
+  choices: readonly BattleInterruptProcedureChoice[],
+):
+  | readonly [
+      BattleInterruptProcedureChoice,
+      ...BattleInterruptProcedureChoice[],
+    ]
+  | null {
+  const first = choices[0];
+  return first === undefined ? null : [first, ...choices.slice(1)];
+}
+
+function openPreparedInterruptWindowWithChoices(
+  checkpointState: BattleState,
+  frame: BattleInterruptCheckpointInput,
+  choices: readonly [
+    BattleInterruptProcedureChoice,
+    ...BattleInterruptProcedureChoice[],
+  ],
+): BattleOpenedInterruptWindowResult {
   const eligibleResponders = [
     ...new Set(choices.map((choice) => choice.reactorId)),
   ];

--- a/packages/battle-runtime/src/battle-reducer/slow-active-penalties-runtime.ts
+++ b/packages/battle-runtime/src/battle-reducer/slow-active-penalties-runtime.ts
@@ -40,8 +40,16 @@ type SlowSomaticSpellFailureSubject =
   | BonusActionSpellBattleResolutionInput["subject"]
   | BonusActionDashSpellBattleResolutionInput["subject"];
 
+export type BattleFillAfterSlowSomaticSpellFailureOutcome = Exclude<
+  BattleFill,
+  { readonly kind: "slowSomaticSpellFailureOutcome" }
+>;
+
 type SlowSomaticSpellFailureResolution =
-  | { readonly tag: "continue"; readonly fills: readonly BattleFill[] }
+  | {
+      readonly tag: "continue";
+      readonly fills: readonly BattleFillAfterSlowSomaticSpellFailureOutcome[];
+    }
   | BattleResolutionResult;
 
 export function combatantHasSlowActivePenalties(
@@ -122,9 +130,10 @@ export function resolveSlowSomaticSpellFailure(input: {
       { readonly kind: "slowSomaticSpellFailureOutcome" }
     > => fill.kind === "slowSomaticSpellFailureOutcome",
   );
+  const remainingFills = fillsAfterSlowSomaticSpellFailureOutcome(input.fills);
   if (hole === null) {
     return fills.length === 0
-      ? { tag: "continue", fills: input.fills }
+      ? { tag: "continue", fills: remainingFills }
       : invalidResult(
           input.state,
           "invalidFill",
@@ -163,7 +172,16 @@ export function resolveSlowSomaticSpellFailure(input: {
           ? {}
           : { metamagicApplications: input.metamagicApplications }),
       })
-    : { tag: "continue", fills: input.fills };
+    : { tag: "continue", fills: remainingFills };
+}
+
+export function fillsAfterSlowSomaticSpellFailureOutcome(
+  fills: readonly BattleFill[],
+): readonly BattleFillAfterSlowSomaticSpellFailureOutcome[] {
+  return fills.filter(
+    (fill): fill is BattleFillAfterSlowSomaticSpellFailureOutcome =>
+      fill.kind !== "slowSomaticSpellFailureOutcome",
+  );
 }
 
 function slowActivePenaltiesEffects(

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-attack-override.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-attack-override.ts
@@ -16,180 +16,22 @@
 import {
   maybeOpenInterruptWindow,
   snapshotBattle,
-  type BattleActDiscoveryCandidate,
-  type BattleActiveEffect,
-  type BattleCreatureState,
-  type BattleResolutionResult,
-  type BattleState,
   type BonusActionSpellBattleResolutionInput,
 } from "../../battle-reducer.ts";
-import { type CombatantId } from "../../identity.ts";
 import {
   admitWeaponAttackOverride,
   type WeaponAttackOverrideInvocation,
 } from "../../procedure-admission/weapon-attack-override.ts";
-import type { WeaponAttackOverrideProcedureFacts } from "../../procedure-facts/weapon-attack-override.ts";
 import { activeDruidWildShapeEffect } from "../druid-wild-shape.ts";
 import { loadoutWeaponItemIsUsableDuringWildShape } from "../wild-shape-equipment.ts";
 import {
-  activeEffectsAfterWeaponAttackOverride,
+  discoverWeaponAttackOverrideCastAct,
+  resolveWeaponAttackOverride,
   WeaponAttackOverrideExecutionSchema,
 } from "../../procedure-execution/weapon-attack-override.ts";
-import { invalidResult } from "../result-helpers.ts";
 import { spellCastInterruptFrame } from "../spell-cast-interrupt-frame.ts";
 import { spendSpellCastResources } from "../spells-resolve-resources.ts";
-import type {
-  OkSpellFillSet,
-  SpellProcedureProfile,
-  SpellProcedureProfileResolveInput,
-} from "./profile.ts";
-
-type WeaponAttackOverrideResolveInput = SpellProcedureProfileResolveInput<
-  WeaponAttackOverrideInvocation,
-  BonusActionSpellBattleResolutionInput
->;
-
-function discoverWeaponAttackOverrideCastAct(
-  state: BattleState,
-  actorId: CombatantId,
-  invocation: import("../../battle-reducer.ts").BattleExecutableSpellInvocation<WeaponAttackOverrideInvocation>,
-): readonly BattleActDiscoveryCandidate[] {
-  const actor = state.combatants.get(actorId);
-  if (
-    actor?.origin.kind !== "character" ||
-    !weaponAttackOverrideWeaponIsUsable(actor, invocation)
-  ) {
-    return [];
-  }
-  return [
-    {
-      subject: {
-        tag: "bonusActionSpell",
-        actorId,
-        procedureRef: invocation.sourceProcedureRef,
-        mode: { tag: "cast" },
-      },
-      initialHoles: [],
-    },
-  ];
-}
-
-function resolveWeaponAttackOverride(
-  input: WeaponAttackOverrideResolveInput,
-): BattleResolutionResult {
-  if (weaponAttackOverrideFillSetHasDisallowedFills(input.fillSet)) {
-    return invalidResult(
-      input.input.state,
-      "invalidFill",
-      "Weapon attack override spells do not use target, roll, damage, or save fills.",
-    );
-  }
-  if (input.invocation.activeEffect.sourceCombatantId !== input.actorId) {
-    return invalidResult(
-      input.input.state,
-      "unsupportedSubject",
-      "Weapon attack override source combatant does not match the caster.",
-    );
-  }
-  const actor = input.input.state.combatants.get(input.actorId);
-  if (actor === undefined) {
-    return invalidResult(
-      input.input.state,
-      "missingCombatant",
-      "Weapon attack override caster is not in this battle.",
-    );
-  }
-  if (
-    actor.origin.kind !== "character" ||
-    !weaponAttackOverrideWeaponIsUsable(actor, input.invocation)
-  ) {
-    return invalidResult(
-      input.input.state,
-      "unsupportedSubject",
-      "Weapon attack override requires its attached weapon to remain usable.",
-    );
-  }
-  const spellCastReactionWindow = maybeOpenInterruptWindow(
-    input.input.state,
-    spellCastInterruptFrame({
-      casterId: input.actorId,
-      invocation: input.invocation,
-      targetIds: [input.actorId],
-      reactionSpellTargetFacts: input.fillSet.reactionSpellTargetFacts,
-      castingResource: { kind: "bonusAction" },
-      continuation: {
-        kind: "replay",
-        subject: input.input.subject,
-        fills: input.input.fills,
-      },
-    }),
-    input.input.handledInterruptTrigger,
-  );
-  if (spellCastReactionWindow !== null) {
-    return spellCastReactionWindow;
-  }
-
-  const activeEffects: readonly BattleActiveEffect[] =
-    activeEffectsAfterWeaponAttackOverride(
-      actor.activeEffects,
-      input.invocation.sourceProcedureRef,
-      input.invocation.activeEffect,
-    );
-  const effected = {
-    ...input.input.state,
-    combatants: new Map(input.input.state.combatants).set(input.actorId, {
-      ...actor,
-      activeEffects,
-    }),
-  };
-  const resourced = spendSpellCastResources({
-    state: effected,
-    actorId: input.actorId,
-    invocation: input.invocation,
-    errorState: input.input.state,
-  });
-  return resourced.tag === "invalid"
-    ? resourced
-    : {
-        tag: "resolved",
-        state: resourced.state,
-        snapshot: snapshotBattle(resourced.state),
-      };
-}
-
-function weaponAttackOverrideWeaponIsUsable(
-  actor: BattleCreatureState,
-  invocation: Pick<WeaponAttackOverrideProcedureFacts, "activeEffect">,
-): boolean {
-  if (actor.origin.kind !== "character") {
-    return false;
-  }
-  return loadoutWeaponItemIsUsableDuringWildShape({
-    loadout: actor.origin.selectedLoadout,
-    activeWildShape: activeDruidWildShapeEffect(actor),
-    itemId: invocation.activeEffect.weaponItemId,
-  });
-}
-
-function weaponAttackOverrideFillSetHasDisallowedFills(
-  fillSet: OkSpellFillSet,
-): boolean {
-  return (
-    fillSet.targetId !== undefined ||
-    fillSet.targetList !== undefined ||
-    fillSet.attackRoll !== undefined ||
-    fillSet.targetAllocation !== undefined ||
-    fillSet.damageRoll !== undefined ||
-    fillSet.attackBurstDamageRoll !== undefined ||
-    fillSet.healingRoll !== undefined ||
-    fillSet.damageDispositions.length > 0 ||
-    fillSet.skillChoice !== undefined ||
-    fillSet.targetAbilityChoices !== undefined ||
-    fillSet.commandOptionChoice !== undefined ||
-    fillSet.savingThrowOutcomes !== undefined ||
-    fillSet.concentrationSavingThrows.length > 0
-  );
-}
+import type { SpellProcedureProfile } from "./profile.ts";
 
 export const weaponAttackOverrideProfile: SpellProcedureProfile<
   "weaponAttackOverride",
@@ -206,6 +48,25 @@ export const weaponAttackOverrideProfile: SpellProcedureProfile<
       actor: ctx.actor,
       activeDruidWildShape: activeDruidWildShapeEffect(ctx.actor),
     }),
-  discoverCastAct: discoverWeaponAttackOverrideCastAct,
-  resolve: resolveWeaponAttackOverride,
+  discoverCastAct: (state, actorId, invocation) =>
+    discoverWeaponAttackOverrideCastAct(state, actorId, invocation, {
+      activeDruidWildShapeEffect,
+      loadoutWeaponItemIsUsableDuringWildShape,
+    }),
+  resolve: (input) =>
+    resolveWeaponAttackOverride(input, {
+      snapshot: snapshotBattle,
+      activeDruidWildShapeEffect,
+      loadoutWeaponItemIsUsableDuringWildShape,
+      spellCastInterruptFrame,
+      maybeOpenInterruptWindow,
+      replaceActorActiveEffects: (state, actorId, actor, activeEffects) => ({
+        ...state,
+        combatants: new Map(state.combatants).set(actorId, {
+          ...actor,
+          activeEffects,
+        }),
+      }),
+      spendSpellCastResources,
+    }),
 };

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-attack-override.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-attack-override.ts
@@ -14,8 +14,9 @@
 //     Type, and Weapon Property.
 
 import {
-  maybeOpenInterruptWindow,
+  interruptWindowProgress,
   snapshotBattle,
+  type BattleInterruptWindowProgress,
   type BonusActionSpellBattleResolutionInput,
 } from "../../battle-reducer.ts";
 import {
@@ -26,18 +27,86 @@ import { activeDruidWildShapeEffect } from "../druid-wild-shape.ts";
 import { loadoutWeaponItemIsUsableDuringWildShape } from "../wild-shape-equipment.ts";
 import {
   discoverWeaponAttackOverrideCastAct,
-  resolveWeaponAttackOverride,
+  weaponAttackOverrideExecutor,
   WeaponAttackOverrideExecutionSchema,
 } from "../../procedure-execution/weapon-attack-override.ts";
 import { spellCastInterruptFrame } from "../spell-cast-interrupt-frame.ts";
 import { spendSpellCastResources } from "../spells-resolve-resources.ts";
+import type { WeaponAttackOverrideFillInput } from "../weapon-attack-override-fill-input.ts";
 import type { SpellProcedureProfile } from "./profile.ts";
 
-export const weaponAttackOverrideProfile: SpellProcedureProfile<
+type WeaponAttackOverrideProfile = SpellProcedureProfile<
   "weaponAttackOverride",
   WeaponAttackOverrideInvocation,
-  BonusActionSpellBattleResolutionInput
-> = {
+  BonusActionSpellBattleResolutionInput,
+  WeaponAttackOverrideFillInput
+>;
+
+type WeaponAttackOverrideOpenedInterruptResult = Extract<
+  BattleInterruptWindowProgress,
+  { readonly tag: "windowOpened" }
+>["result"];
+type WeaponAttackOverrideCheckpointFailureResult = Extract<
+  BattleInterruptWindowProgress,
+  { readonly tag: "checkpointPreparationFailed" }
+>["result"];
+
+const resolveWeaponAttackOverride = weaponAttackOverrideExecutor<
+  WeaponAttackOverrideOpenedInterruptResult,
+  WeaponAttackOverrideCheckpointFailureResult
+>();
+
+function resolveWeaponAttackOverrideProfile(
+  input: Parameters<WeaponAttackOverrideProfile["resolve"]>[0],
+) {
+  const continuation = {
+    kind: "replay",
+    subject: input.input.subject,
+    fills: input.input.fills,
+  } as const;
+  return resolveWeaponAttackOverride(
+    {
+      input: {
+        state: input.input.state,
+        subject: input.input.subject,
+        ...(input.input.handledInterruptTrigger === undefined
+          ? {}
+          : {
+              handledInterruptTrigger: input.input.handledInterruptTrigger,
+            }),
+      },
+      invocation: input.invocation,
+      fillInput: input.fillSet,
+      continuation,
+    },
+    {
+      snapshot: snapshotBattle,
+      activeDruidWildShapeEffect,
+      loadoutWeaponItemIsUsableDuringWildShape,
+      spellCastInterruptFrame,
+      interruptWindowProgress,
+      commitWeaponAttackOverrideEffect: ({ authorization, activeEffects }) => ({
+        ...authorization.execution.state,
+        combatants: new Map(authorization.execution.state.combatants).set(
+          authorization.execution.caster.combatantId,
+          {
+            ...authorization.execution.caster,
+            activeEffects,
+          },
+        ),
+      }),
+      spendSpellCastResources: ({ state, execution, errorState }) =>
+        spendSpellCastResources({
+          state,
+          actorId: execution.caster.combatantId,
+          invocation: execution.invocation,
+          errorState,
+        }),
+    },
+  );
+}
+
+export const weaponAttackOverrideProfile: WeaponAttackOverrideProfile = {
   procedure: "weaponAttackOverride",
   executionSchema: WeaponAttackOverrideExecutionSchema,
   metamagicCompatibility: "notActionSpellCasting",
@@ -53,20 +122,5 @@ export const weaponAttackOverrideProfile: SpellProcedureProfile<
       activeDruidWildShapeEffect,
       loadoutWeaponItemIsUsableDuringWildShape,
     }),
-  resolve: (input) =>
-    resolveWeaponAttackOverride(input, {
-      snapshot: snapshotBattle,
-      activeDruidWildShapeEffect,
-      loadoutWeaponItemIsUsableDuringWildShape,
-      spellCastInterruptFrame,
-      maybeOpenInterruptWindow,
-      replaceActorActiveEffects: (state, actorId, actor, activeEffects) => ({
-        ...state,
-        combatants: new Map(state.combatants).set(actorId, {
-          ...actor,
-          activeEffects,
-        }),
-      }),
-      spendSpellCastResources,
-    }),
+  resolve: resolveWeaponAttackOverrideProfile,
 };

--- a/packages/battle-runtime/src/battle-reducer/spells-resolve.ts
+++ b/packages/battle-runtime/src/battle-reducer/spells-resolve.ts
@@ -277,7 +277,11 @@ import {
   targetChoiceFillAfterSanctuaryAttackRollReplacement,
 } from "./sanctuary-targeting-interdiction.ts";
 import { spellCastInterruptFrame } from "./spell-cast-interrupt-frame.ts";
-import { resolveSlowSomaticSpellFailure } from "./slow-active-penalties-runtime.ts";
+import {
+  fillsAfterSlowSomaticSpellFailureOutcome,
+  resolveSlowSomaticSpellFailure,
+} from "./slow-active-penalties-runtime.ts";
+import { parseWeaponAttackOverrideFillInput } from "./weapon-attack-override-fill-input.ts";
 
 import { spellFillSet, type SpellFillSet } from "./spells-resolve-fill-set.ts";
 
@@ -660,6 +664,11 @@ type BonusActionSpellProfileInvocation = Extract<
   {
     readonly procedure: (typeof BONUS_ACTION_SPELL_PROFILE_PROCEDURES)[number];
   }
+>;
+
+type OrdinaryBonusActionSpellProfileInvocation = Exclude<
+  BonusActionSpellProfileInvocation,
+  { readonly procedure: "weaponAttackOverride" }
 >;
 
 function invocationProcedureIsIn<
@@ -1524,7 +1533,7 @@ function bonusActionSpellProcedureResolveDispatchInput(
   input: BonusActionSpellBattleResolutionInput,
   castingState: BattleState,
   actorId: CombatantId,
-  invocation: BonusActionSpellProfileInvocation,
+  invocation: OrdinaryBonusActionSpellProfileInvocation,
   fillSet: Extract<SpellFillSet, { readonly tag: "ok" }>,
   resolutionOptions: SpellProcedureResolutionOptions,
 ): SpellProcedureResolveDispatchInput {
@@ -1711,21 +1720,6 @@ function bonusActionSpellProcedureResolveDispatchInput(
               }),
         }),
       weaponDamageRider: (value) =>
-        spellProcedureResolveDispatchInput(value.procedure, {
-          input: { ...input, state: castingState },
-          actorId,
-          invocation: value,
-          fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
-          ...(resolutionOptions.metamagicApplications === undefined
-            ? {}
-            : {
-                metamagicApplications: resolutionOptions.metamagicApplications,
-              }),
-        }),
-      weaponAttackOverride: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
           input: { ...input, state: castingState },
           actorId,
@@ -4779,16 +4773,38 @@ export function resolveBonusActionSpellAct(
     invocation.spellRuleFacts.components.verbal
       ? revealHidden(input.state, subject.actorId)
       : input.state;
-  const slowSomaticSpellFailure = resolveSlowSomaticSpellFailure({
-    state: input.state,
-    castingState,
-    subject,
-    actorId: subject.actorId,
-    invocation,
-    fills: input.fills,
-    ...(actionCostOverride === undefined ? {} : { actionCostOverride }),
-    metamagicApplications: metamagicAdmission.applications,
-  });
+  const resolveSlowSomaticFailurePhase = () =>
+    resolveSlowSomaticSpellFailure({
+      state: input.state,
+      castingState,
+      subject,
+      actorId: subject.actorId,
+      invocation,
+      fills: input.fills,
+      ...(actionCostOverride === undefined ? {} : { actionCostOverride }),
+      metamagicApplications: metamagicAdmission.applications,
+    });
+  if (invocation.procedure === "weaponAttackOverride") {
+    const parsedFillInput = parseWeaponAttackOverrideFillInput(
+      fillsAfterSlowSomaticSpellFailureOutcome(input.fills),
+    );
+    if (parsedFillInput.tag === "invalid") {
+      return invalidResult(input.state, "invalidFill", parsedFillInput.message);
+    }
+    const slowSomaticSpellFailure = resolveSlowSomaticFailurePhase();
+    if (slowSomaticSpellFailure.tag !== "continue") {
+      return slowSomaticSpellFailure;
+    }
+    return resolveRegisteredSpellProcedureProfile(
+      spellProcedureResolveDispatchInput(invocation.procedure, {
+        input: { ...input, state: castingState },
+        actorId: subject.actorId,
+        invocation,
+        fillSet: parsedFillInput.input,
+      }),
+    );
+  }
+  const slowSomaticSpellFailure = resolveSlowSomaticFailurePhase();
   if (slowSomaticSpellFailure.tag !== "continue") {
     return slowSomaticSpellFailure;
   }

--- a/packages/battle-runtime/src/battle-reducer/weapon-attack-override-fill-input.ts
+++ b/packages/battle-runtime/src/battle-reducer/weapon-attack-override-fill-input.ts
@@ -1,0 +1,128 @@
+import { Match } from "effect";
+import type {
+  BattleFill,
+  BattleSpellCastReactionFact,
+} from "../battle-reducer.ts";
+import type { BattleFillAfterSlowSomaticSpellFailureOutcome } from "./slow-active-penalties-runtime.ts";
+import { parseSpellCastReactionFactsFill } from "./spells-resolve-fill-set.ts";
+
+export type WeaponAttackOverrideFillInput = {
+  readonly reactionFacts: readonly BattleSpellCastReactionFact[];
+};
+
+export type WeaponAttackOverrideFillInputParseResult =
+  | {
+      readonly tag: "parsed";
+      readonly input: WeaponAttackOverrideFillInput;
+    }
+  | { readonly tag: "invalid"; readonly message: string };
+
+type WeaponAttackOverrideFillClassification =
+  | {
+      readonly tag: "reactionFacts";
+      readonly facts: readonly BattleSpellCastReactionFact[];
+    }
+  | { readonly tag: "invalid"; readonly message: string };
+
+const ORDINARY_FILL_MESSAGE =
+  "Weapon attack override spells do not use target, roll, damage, or save fills.";
+
+function ordinaryFillIsInvalid(): WeaponAttackOverrideFillClassification {
+  return { tag: "invalid", message: ORDINARY_FILL_MESSAGE };
+}
+
+function classifyTargetSpatialFactsFill(
+  fill: Extract<BattleFill, { readonly kind: "targetSpatialFacts" }>,
+): WeaponAttackOverrideFillClassification {
+  const parsed = parseSpellCastReactionFactsFill(fill);
+  return parsed.tag === "ok"
+    ? { tag: "reactionFacts", facts: parsed.facts }
+    : {
+        tag: "invalid",
+        message:
+          parsed.tag === "invalid" ? parsed.message : ORDINARY_FILL_MESSAGE,
+      };
+}
+
+function classifyWeaponAttackOverrideFill(
+  fill: BattleFillAfterSlowSomaticSpellFailureOutcome,
+): WeaponAttackOverrideFillClassification {
+  return Match.value(fill).pipe(
+    Match.discriminatorsExhaustive("kind")({
+      helpAttackAllyDecision: ordinaryFillIsInvalid,
+      helpAttackEnemyDecision: ordinaryFillIsInvalid,
+      attackRoll: ordinaryFillIsInvalid,
+      creatureAttackZeroDamage: ordinaryFillIsInvalid,
+      rolledDice: ordinaryFillIsInvalid,
+      damageTypeChoice: ordinaryFillIsInvalid,
+      savingThrowOutcome: ordinaryFillIsInvalid,
+      conditionChoice: ordinaryFillIsInvalid,
+      skillChoice: ordinaryFillIsInvalid,
+      abilityChoice: ordinaryFillIsInvalid,
+      targetAbilityChoices: ordinaryFillIsInvalid,
+      thaumaturgyActiveOneMinuteEffectCount: ordinaryFillIsInvalid,
+      commandOptionChoice: ordinaryFillIsInvalid,
+      selfTransformationModeChoice: ordinaryFillIsInvalid,
+      wildShapeEquipmentDisposition: ordinaryFillIsInvalid,
+      dancingLightsPlacement: ordinaryFillIsInvalid,
+      unitFeatureDecision: ordinaryFillIsInvalid,
+      hitPointHealingDistribution: ordinaryFillIsInvalid,
+      heldObjectFacts: ordinaryFillIsInvalid,
+      toolPossessionFacts: ordinaryFillIsInvalid,
+      cunningStrikeEndTurnCoverFacts: ordinaryFillIsInvalid,
+      findFamiliarConnection: ordinaryFillIsInvalid,
+      companionReappearancePlacement: ordinaryFillIsInvalid,
+      companionReappearanceInitiative: ordinaryFillIsInvalid,
+      magicWeaponTargetItem: ordinaryFillIsInvalid,
+      targetChoice: ordinaryFillIsInvalid,
+      damageRelationshipDecisions: ordinaryFillIsInvalid,
+      targetSpatialFacts: classifyTargetSpatialFactsFill,
+      objectTargetChoice: ordinaryFillIsInvalid,
+      ongoingSpellTargetChoice: ordinaryFillIsInvalid,
+      objectContactTargets: ordinaryFillIsInvalid,
+      objectDropResolution: ordinaryFillIsInvalid,
+      spellAreaChoice: ordinaryFillIsInvalid,
+      gustOfWindLineDirectionChoice: ordinaryFillIsInvalid,
+      movableZoneRamMovement: ordinaryFillIsInvalid,
+      movableZoneRepositionMovement: ordinaryFillIsInvalid,
+      teleportDestination: ordinaryFillIsInvalid,
+      spiritualWeaponForcePosition: ordinaryFillIsInvalid,
+      spellTargetAllocation: ordinaryFillIsInvalid,
+      spellTargetList: ordinaryFillIsInvalid,
+      deathSavingThrow: ordinaryFillIsInvalid,
+      statBlockRechargeRoll: ordinaryFillIsInvalid,
+      concentrationSavingThrow: ordinaryFillIsInvalid,
+      attackDamageDisposition: ordinaryFillIsInvalid,
+      sanctuaryInterdictionOutcome: ordinaryFillIsInvalid,
+      interruptDecision: ordinaryFillIsInvalid,
+      movement: ordinaryFillIsInvalid,
+      levitateAltitudeChange: ordinaryFillIsInvalid,
+      levitateInitialRise: ordinaryFillIsInvalid,
+      abilityCheck: ordinaryFillIsInvalid,
+      grappleOutcome: ordinaryFillIsInvalid,
+      shoveOutcome: ordinaryFillIsInvalid,
+    }),
+  );
+}
+
+export function parseWeaponAttackOverrideFillInput(
+  fills: readonly BattleFillAfterSlowSomaticSpellFailureOutcome[],
+): WeaponAttackOverrideFillInputParseResult {
+  let reactionFacts: readonly BattleSpellCastReactionFact[] = [];
+  let reactionFactsWereSupplied = false;
+  for (const fill of fills) {
+    const classification = classifyWeaponAttackOverrideFill(fill);
+    if (classification.tag === "invalid") {
+      return classification;
+    }
+    if (reactionFactsWereSupplied) {
+      return {
+        tag: "invalid",
+        message: "Spell-cast Reaction trigger facts were filled twice.",
+      };
+    }
+    reactionFacts = classification.facts;
+    reactionFactsWereSupplied = true;
+  }
+  return { tag: "parsed", input: { reactionFacts } };
+}

--- a/packages/battle-runtime/src/counterspell-reaction-spell.test.ts
+++ b/packages/battle-runtime/src/counterspell-reaction-spell.test.ts
@@ -68,6 +68,30 @@ const counterspellerId = combatantId("counterspell-reactor");
 const secondCounterspellerId = combatantId("counterspell-second-reactor");
 
 describe("Counterspell Reaction spell", () => {
+  test("an inherited attack trigger does not suppress the distinct spell-cast window", () => {
+    const session = battleWithCounterspell();
+
+    expect(
+      startMagicMissile({
+        session,
+        state: session.state,
+        slotLevel: 1,
+        targetId: counterspellerId,
+        handledInterruptTrigger: "attackHit",
+        counterspellFacts: [
+          counterspellTriggerFact({
+            session,
+            reactorId: counterspellerId,
+            casterId,
+          }),
+        ],
+      }),
+    ).toMatchObject({
+      tag: "needsHoles",
+      snapshot: { pendingInterrupt: { trigger: "spellCast" } },
+    });
+  });
+
   test("ends a lower-level spell automatically without expending the triggering slot", () => {
     const session = battleWithCounterspell();
     const state = session.state;
@@ -998,6 +1022,7 @@ function startMagicMissile(input: {
   readonly state: BattleState;
   readonly slotLevel: number;
   readonly targetId: CombatantId;
+  readonly handledInterruptTrigger?: "attackHit";
   readonly counterspellFacts: readonly CounterspellTriggerFact[];
 }): StartedMagicMissile {
   const subject = magicMissileSubject(input.session, input.slotLevel);
@@ -1022,6 +1047,9 @@ function startMagicMissile(input: {
   const result = resolveBattleSubject({
     state: input.state,
     subject,
+    ...(input.handledInterruptTrigger === undefined
+      ? {}
+      : { handledInterruptTrigger: input.handledInterruptTrigger }),
     fills: [
       targetAllocationFill,
       spellCastReactionFactsFill(

--- a/packages/battle-runtime/src/procedure-execution/spell-cast-reaction-protocol.ts
+++ b/packages/battle-runtime/src/procedure-execution/spell-cast-reaction-protocol.ts
@@ -1,0 +1,11 @@
+import {
+  holeId,
+  holeInstanceKey,
+} from "@dnd/shared-algebras/runtime-hole-algebra";
+
+export const SPELL_CAST_REACTION_FACTS_HOLE_ID = holeId(
+  "battle:spell-cast:reaction-facts",
+);
+export const SPELL_CAST_REACTION_FACTS_HOLE_INSTANCE = holeInstanceKey(
+  "battle:spell-cast:reaction-facts",
+);

--- a/packages/battle-runtime/src/procedure-execution/weapon-attack-override.ts
+++ b/packages/battle-runtime/src/procedure-execution/weapon-attack-override.ts
@@ -1,7 +1,6 @@
 import { AbilityModifier, AttackBonus } from "@dnd/shared/types";
-import type { HoleId } from "@dnd/shared-algebras/runtime-hole-algebra";
 import { DamageTypeSchema, DiceExprSchema } from "@dnd/surface/surface/schema";
-import { Schema } from "effect";
+import { Match, Schema } from "effect";
 import { DurationBattleActiveEffectExpirationSchema } from "../active-effect/expiration-codecs.ts";
 import type { BattleActiveEffectIdentity } from "../active-effect/source.ts";
 import {
@@ -21,7 +20,6 @@ import {
   SpellRuleExecutionFactsSchema,
   type SpellRuleExecutionFacts,
 } from "./spell-rule-facts.ts";
-import { SPELL_CAST_REACTION_FACTS_HOLE_ID } from "./spell-cast-reaction-protocol.ts";
 
 /** Authored-identity-free facts consumed by weapon-attack-override execution. */
 export type WeaponAttackOverrideSpellProcedureExecution =
@@ -35,6 +33,7 @@ export type SpellWeaponAttackOverrideEffect =
   };
 
 type WeaponAttackOverrideActor<ActiveEffect, SelectedLoadout> = {
+  readonly combatantId: CombatantId;
   readonly origin:
     | {
         readonly kind: "character";
@@ -53,13 +52,8 @@ type WeaponAttackOverrideExecutableInvocation =
     readonly sourceProcedureRef: BattleProcedureExecutionRef;
   };
 
-type WeaponAttackOverrideFillSet<ReactionSpellTargetFact> = {
-  readonly reactionSpellTargetFacts: readonly ReactionSpellTargetFact[];
-};
-
-type WeaponAttackOverrideFill = {
-  readonly kind: string;
-  readonly holeId: HoleId;
+type WeaponAttackOverrideFillInput<ReactionFact> = {
+  readonly reactionFacts: readonly ReactionFact[];
 };
 
 type WeaponAttackOverrideSubject = {
@@ -76,14 +70,8 @@ type WeaponAttackOverrideDiscoveryCandidate = {
 
 type WeaponAttackOverrideInvalidResult<Snapshot> = {
   readonly tag: "invalid";
-  readonly reason: "invalidFill" | "unsupportedSubject" | "missingCombatant";
+  readonly reason: "unsupportedSubject" | "missingCombatant";
   readonly message: string;
-  readonly snapshot: Snapshot;
-};
-
-type WeaponAttackOverrideResolvedResult<State, Snapshot> = {
-  readonly tag: "resolved";
-  readonly state: State;
   readonly snapshot: Snapshot;
 };
 
@@ -98,11 +86,21 @@ type WeaponAttackOverrideSharedInvalidResult<Snapshot> = {
   readonly snapshot: Snapshot;
 };
 
-type WeaponAttackOverrideInterruptResult<State, Snapshot> = {
+type WeaponAttackOverrideOpenedInterruptResult<State, Snapshot> = {
   readonly tag: "needsHoles";
   readonly state: State;
+  readonly subject: unknown;
   readonly snapshot: Snapshot;
+  readonly holes: readonly [unknown, ...unknown[]];
 };
+
+type WeaponAttackOverrideInterruptProgress<InvalidResult, OpenedResult> =
+  | {
+      readonly tag: "checkpointPreparationFailed";
+      readonly result: InvalidResult;
+    }
+  | { readonly tag: "interruptionsCleared" }
+  | { readonly tag: "windowOpened"; readonly result: OpenedResult };
 
 type WeaponAttackOverrideUsabilityRuntime<
   Actor,
@@ -184,171 +182,199 @@ export function discoverWeaponAttackOverrideCastAct<
   ];
 }
 
-export function resolveWeaponAttackOverride<
-  SelectedLoadout,
-  Actor extends WeaponAttackOverrideActor<
-    BattleActiveEffectIdentity,
-    SelectedLoadout
-  >,
-  State extends WeaponAttackOverrideBattleState<Actor>,
-  Invocation extends WeaponAttackOverrideExecutableInvocation,
-  Fill extends WeaponAttackOverrideFill,
-  ReactionSpellTargetFact,
-  FillSet extends WeaponAttackOverrideFillSet<ReactionSpellTargetFact>,
-  HandledInterruptTrigger,
-  InterruptFrame,
-  Snapshot,
-  InterruptResult extends WeaponAttackOverrideInterruptResult<State, Snapshot>,
-  ResourceInvalidResult extends
-    WeaponAttackOverrideSharedInvalidResult<Snapshot>,
-  ActiveDruidWildShape,
->(
-  input: {
-    readonly input: {
-      readonly state: State & WeaponAttackOverrideBattleState<Actor>;
-      readonly subject: WeaponAttackOverrideSubject;
-      readonly fills: readonly Fill[];
-      readonly handledInterruptTrigger?: HandledInterruptTrigger | undefined;
-    };
-    readonly actorId: CombatantId;
-    readonly invocation: Invocation;
-    readonly fillSet: FillSet;
-  },
-  runtime: {
-    readonly snapshot: (state: State) => Snapshot;
-    readonly activeDruidWildShapeEffect: (actor: Actor) => ActiveDruidWildShape;
-    readonly loadoutWeaponItemIsUsableDuringWildShape: (input: {
-      readonly loadout: SelectedLoadout;
-      readonly activeWildShape: ActiveDruidWildShape;
-      readonly itemId: BattleObjectId;
-    }) => boolean;
-    readonly spellCastInterruptFrame: (input: {
-      readonly casterId: CombatantId;
-      readonly invocation: Invocation;
-      readonly targetIds: readonly CombatantId[];
-      readonly reactionSpellTargetFacts: readonly ReactionSpellTargetFact[];
-      readonly castingResource: { readonly kind: "bonusAction" };
-      readonly continuation: {
-        readonly kind: "replay";
+export function weaponAttackOverrideExecutor<
+  InterruptResult,
+  ResourceInvalidResult,
+>() {
+  return function resolveWeaponAttackOverride<
+    SelectedLoadout,
+    Actor extends WeaponAttackOverrideActor<
+      BattleActiveEffectIdentity,
+      SelectedLoadout
+    >,
+    State extends WeaponAttackOverrideBattleState<Actor>,
+    Invocation extends WeaponAttackOverrideExecutableInvocation,
+    ReactionFact,
+    FillInput extends WeaponAttackOverrideFillInput<ReactionFact>,
+    Continuation,
+    HandledInterruptTrigger,
+    InterruptFrame,
+    Snapshot,
+    ActiveDruidWildShape,
+  >(
+    input: {
+      readonly input: {
+        readonly state: State & WeaponAttackOverrideBattleState<Actor>;
         readonly subject: WeaponAttackOverrideSubject;
-        readonly fills: readonly Fill[];
+        readonly handledInterruptTrigger?: HandledInterruptTrigger | undefined;
       };
-    }) => InterruptFrame;
-    readonly maybeOpenInterruptWindow: (
-      state: State,
-      frame: InterruptFrame,
-      handledInterruptTrigger: HandledInterruptTrigger | undefined,
-    ) => InterruptResult | null;
-    readonly replaceActorActiveEffects: (
-      state: State,
-      actorId: CombatantId,
-      actor: Actor,
-      activeEffects: readonly (
-        | Actor["activeEffects"][number]
-        | SpellWeaponAttackOverrideEffect
-      )[],
-    ) => State;
-    readonly spendSpellCastResources: (input: {
-      readonly state: State;
-      readonly actorId: CombatantId;
       readonly invocation: Invocation;
-      readonly errorState: State;
-    }) => WeaponAttackOverrideResourceSpendResult<State, ResourceInvalidResult>;
-  },
-):
-  | WeaponAttackOverrideInvalidResult<Snapshot>
-  | WeaponAttackOverrideResolvedResult<State, Snapshot>
-  | ResourceInvalidResult
-  | InterruptResult {
-  const invalid = (
-    reason: WeaponAttackOverrideInvalidResult<Snapshot>["reason"],
-    message: string,
-  ): WeaponAttackOverrideInvalidResult<Snapshot> => ({
-    tag: "invalid",
-    reason,
-    message,
-    snapshot: runtime.snapshot(input.input.state),
-  });
+      readonly fillInput: FillInput;
+      readonly continuation: Continuation;
+    },
+    runtime: {
+      readonly snapshot: (state: State) => Snapshot;
+      readonly activeDruidWildShapeEffect: (
+        actor: Actor,
+      ) => ActiveDruidWildShape;
+      readonly loadoutWeaponItemIsUsableDuringWildShape: (input: {
+        readonly loadout: SelectedLoadout;
+        readonly activeWildShape: ActiveDruidWildShape;
+        readonly itemId: BattleObjectId;
+      }) => boolean;
+      readonly spellCastInterruptFrame: (input: {
+        readonly casterId: CombatantId;
+        readonly invocation: Invocation;
+        readonly targetIds: readonly CombatantId[];
+        readonly reactionSpellTargetFacts: readonly ReactionFact[];
+        readonly castingResource: { readonly kind: "bonusAction" };
+        readonly continuation: Continuation;
+      }) => InterruptFrame;
+      readonly interruptWindowProgress: (
+        state: State,
+        frame: InterruptFrame,
+        handledInterruptTrigger: HandledInterruptTrigger | undefined,
+      ) => WeaponAttackOverrideInterruptProgress<
+        ResourceInvalidResult &
+          WeaponAttackOverrideSharedInvalidResult<Snapshot>,
+        InterruptResult &
+          WeaponAttackOverrideOpenedInterruptResult<State, Snapshot>
+      >;
+      readonly commitWeaponAttackOverrideEffect: (plan: {
+        readonly authorization: {
+          readonly tag: "interruptionsCleared";
+          readonly execution: {
+            readonly state: State;
+            readonly subject: WeaponAttackOverrideSubject;
+            readonly caster: Actor;
+            readonly invocation: Invocation;
+            readonly continuation: Continuation;
+          };
+        };
+        readonly activeEffects: readonly (
+          | Actor["activeEffects"][number]
+          | SpellWeaponAttackOverrideEffect
+        )[];
+      }) => State;
+      readonly spendSpellCastResources: (input: {
+        readonly state: State;
+        readonly execution: {
+          readonly subject: WeaponAttackOverrideSubject;
+          readonly caster: Actor;
+          readonly invocation: Invocation;
+        };
+        readonly errorState: State;
+      }) => WeaponAttackOverrideResourceSpendResult<
+        State,
+        ResourceInvalidResult &
+          WeaponAttackOverrideSharedInvalidResult<Snapshot>
+      >;
+    },
+  ):
+    | WeaponAttackOverrideInvalidResult<Snapshot>
+    | ResourceInvalidResult
+    | InterruptResult
+    | {
+        readonly tag: "resolved";
+        readonly state: State;
+        readonly snapshot: Snapshot;
+      } {
+    const invalid = (
+      reason: WeaponAttackOverrideInvalidResult<Snapshot>["reason"],
+      message: string,
+    ): WeaponAttackOverrideInvalidResult<Snapshot> => ({
+      tag: "invalid",
+      reason,
+      message,
+      snapshot: runtime.snapshot(input.input.state),
+    });
 
-  if (weaponAttackOverrideFillsHaveDisallowedFill(input.input.fills)) {
-    return invalid(
-      "invalidFill",
-      "Weapon attack override spells do not use target, roll, damage, or save fills.",
-    );
-  }
-  if (input.invocation.activeEffect.sourceCombatantId !== input.actorId) {
-    return invalid(
-      "unsupportedSubject",
-      "Weapon attack override source combatant does not match the caster.",
-    );
-  }
-  const actor = input.input.state.combatants.get(input.actorId);
-  if (actor === undefined) {
-    return invalid(
-      "missingCombatant",
-      "Weapon attack override caster is not in this battle.",
-    );
-  }
-  if (!weaponAttackOverrideWeaponIsUsable(actor, input.invocation, runtime)) {
-    return invalid(
-      "unsupportedSubject",
-      "Weapon attack override requires its attached weapon to remain usable.",
-    );
-  }
-  const spellCastReactionWindow = runtime.maybeOpenInterruptWindow(
-    input.input.state,
-    runtime.spellCastInterruptFrame({
-      casterId: input.actorId,
+    if (
+      input.input.subject.procedureRef !==
+        input.invocation.sourceProcedureRef ||
+      input.invocation.activeEffect.sourceCombatantId !==
+        input.input.subject.actorId
+    ) {
+      return invalid(
+        "unsupportedSubject",
+        "Weapon attack override subject, caster, and procedure identity do not match.",
+      );
+    }
+    const actor = input.input.state.combatants.get(input.input.subject.actorId);
+    if (actor === undefined) {
+      return invalid(
+        "missingCombatant",
+        "Weapon attack override caster is not in this battle.",
+      );
+    }
+    if (actor.combatantId !== input.input.subject.actorId) {
+      return invalid(
+        "unsupportedSubject",
+        "Weapon attack override caster identity does not match its battle-state key.",
+      );
+    }
+    if (!weaponAttackOverrideWeaponIsUsable(actor, input.invocation, runtime)) {
+      return invalid(
+        "unsupportedSubject",
+        "Weapon attack override requires its attached weapon to remain usable.",
+      );
+    }
+    const execution = {
+      state: input.input.state,
+      subject: input.input.subject,
+      caster: actor,
       invocation: input.invocation,
-      targetIds: [input.actorId],
-      reactionSpellTargetFacts: input.fillSet.reactionSpellTargetFacts,
-      castingResource: { kind: "bonusAction" },
-      continuation: {
-        kind: "replay",
-        subject: input.input.subject,
-        fills: input.input.fills,
-      },
-    }),
-    input.input.handledInterruptTrigger,
-  );
-  if (spellCastReactionWindow !== null) {
-    return spellCastReactionWindow;
-  }
-
-  const activeEffects = activeEffectsAfterWeaponAttackOverride(
-    actor.activeEffects,
-    input.invocation.sourceProcedureRef,
-    input.invocation.activeEffect,
-  );
-  const effected = runtime.replaceActorActiveEffects(
-    input.input.state,
-    input.actorId,
-    actor,
-    activeEffects,
-  );
-  const resourced = runtime.spendSpellCastResources({
-    state: effected,
-    actorId: input.actorId,
-    invocation: input.invocation,
-    errorState: input.input.state,
-  });
-  return resourced.tag === "invalid"
-    ? resourced
-    : {
-        tag: "resolved",
-        state: resourced.state,
-        snapshot: runtime.snapshot(resourced.state),
-      };
-}
-
-function weaponAttackOverrideFillsHaveDisallowedFill(
-  fills: readonly WeaponAttackOverrideFill[],
-): boolean {
-  return fills.some(
-    (fill) =>
-      fill.kind !== "targetSpatialFacts" ||
-      fill.holeId !== SPELL_CAST_REACTION_FACTS_HOLE_ID,
-  );
+      continuation: input.continuation,
+    };
+    const interruptProgress = runtime.interruptWindowProgress(
+      input.input.state,
+      runtime.spellCastInterruptFrame({
+        casterId: execution.caster.combatantId,
+        invocation: input.invocation,
+        targetIds: [execution.caster.combatantId],
+        reactionSpellTargetFacts: input.fillInput.reactionFacts,
+        castingResource: { kind: "bonusAction" },
+        continuation: input.continuation,
+      }),
+      input.input.handledInterruptTrigger,
+    );
+    if (interruptProgress.tag === "checkpointPreparationFailed") {
+      return interruptProgress.result;
+    }
+    if (interruptProgress.tag === "windowOpened") {
+      return interruptProgress.result;
+    }
+    const clearedProgress = Match.value(interruptProgress).pipe(
+      Match.discriminatorsExhaustive("tag")({
+        interruptionsCleared: (progress) => progress,
+      }),
+    );
+    const authorization = {
+      tag: clearedProgress.tag,
+      execution,
+    } as const;
+    const activeEffects = activeEffectsAfterWeaponAttackOverride(
+      authorization.execution.caster.activeEffects,
+      authorization.execution.invocation.sourceProcedureRef,
+      authorization.execution.invocation.activeEffect,
+    );
+    const effected = runtime.commitWeaponAttackOverrideEffect({
+      authorization,
+      activeEffects,
+    });
+    const resourced = runtime.spendSpellCastResources({
+      state: effected,
+      execution: authorization.execution,
+      errorState: authorization.execution.state,
+    });
+    return resourced.tag === "invalid"
+      ? resourced
+      : {
+          tag: "resolved" as const,
+          state: resourced.state,
+          snapshot: runtime.snapshot(resourced.state),
+        };
+  };
 }
 
 function exactSchema<Expected>() {

--- a/packages/battle-runtime/src/procedure-execution/weapon-attack-override.ts
+++ b/packages/battle-runtime/src/procedure-execution/weapon-attack-override.ts
@@ -1,4 +1,5 @@
 import { AbilityModifier, AttackBonus } from "@dnd/shared/types";
+import type { HoleId } from "@dnd/shared-algebras/runtime-hole-algebra";
 import { DamageTypeSchema, DiceExprSchema } from "@dnd/surface/surface/schema";
 import { Schema } from "effect";
 import { DurationBattleActiveEffectExpirationSchema } from "../active-effect/expiration-codecs.ts";
@@ -20,6 +21,7 @@ import {
   SpellRuleExecutionFactsSchema,
   type SpellRuleExecutionFacts,
 } from "./spell-rule-facts.ts";
+import { SPELL_CAST_REACTION_FACTS_HOLE_ID } from "./spell-cast-reaction-protocol.ts";
 
 /** Authored-identity-free facts consumed by weapon-attack-override execution. */
 export type WeaponAttackOverrideSpellProcedureExecution =
@@ -31,6 +33,323 @@ export type SpellWeaponAttackOverrideEffect =
   SpellWeaponAttackOverrideTemplate & {
     readonly sourceProcedureRef: BattleProcedureExecutionRef;
   };
+
+type WeaponAttackOverrideActor<ActiveEffect, SelectedLoadout> = {
+  readonly origin:
+    | {
+        readonly kind: "character";
+        readonly selectedLoadout: SelectedLoadout;
+      }
+    | { readonly kind: "statBlock" };
+  readonly activeEffects: readonly ActiveEffect[];
+};
+
+type WeaponAttackOverrideBattleState<Actor> = {
+  readonly combatants: ReadonlyMap<CombatantId, Actor>;
+};
+
+type WeaponAttackOverrideExecutableInvocation =
+  WeaponAttackOverrideSpellProcedureExecution & {
+    readonly sourceProcedureRef: BattleProcedureExecutionRef;
+  };
+
+type WeaponAttackOverrideFillSet<ReactionSpellTargetFact> = {
+  readonly reactionSpellTargetFacts: readonly ReactionSpellTargetFact[];
+};
+
+type WeaponAttackOverrideFill = {
+  readonly kind: string;
+  readonly holeId: HoleId;
+};
+
+type WeaponAttackOverrideSubject = {
+  readonly tag: "bonusActionSpell";
+  readonly actorId: CombatantId;
+  readonly procedureRef: BattleProcedureExecutionRef;
+  readonly mode: { readonly tag: "cast" };
+};
+
+type WeaponAttackOverrideDiscoveryCandidate = {
+  readonly subject: WeaponAttackOverrideSubject;
+  readonly initialHoles: readonly [];
+};
+
+type WeaponAttackOverrideInvalidResult<Snapshot> = {
+  readonly tag: "invalid";
+  readonly reason: "invalidFill" | "unsupportedSubject" | "missingCombatant";
+  readonly message: string;
+  readonly snapshot: Snapshot;
+};
+
+type WeaponAttackOverrideResolvedResult<State, Snapshot> = {
+  readonly tag: "resolved";
+  readonly state: State;
+  readonly snapshot: Snapshot;
+};
+
+type WeaponAttackOverrideResourceSpendResult<State, InvalidResult> =
+  | { readonly tag: "resolved"; readonly state: State }
+  | InvalidResult;
+
+type WeaponAttackOverrideSharedInvalidResult<Snapshot> = {
+  readonly tag: "invalid";
+  readonly reason: string;
+  readonly message: string;
+  readonly snapshot: Snapshot;
+};
+
+type WeaponAttackOverrideInterruptResult<State, Snapshot> = {
+  readonly tag: "needsHoles";
+  readonly state: State;
+  readonly snapshot: Snapshot;
+};
+
+type WeaponAttackOverrideUsabilityRuntime<
+  Actor,
+  SelectedLoadout,
+  ActiveDruidWildShape,
+> = {
+  readonly activeDruidWildShapeEffect: (actor: Actor) => ActiveDruidWildShape;
+  readonly loadoutWeaponItemIsUsableDuringWildShape: (input: {
+    readonly loadout: SelectedLoadout;
+    readonly activeWildShape: ActiveDruidWildShape;
+    readonly itemId: BattleObjectId;
+  }) => boolean;
+};
+
+function weaponAttackOverrideWeaponIsUsable<
+  ActiveEffect extends BattleActiveEffectIdentity,
+  SelectedLoadout,
+  Actor extends WeaponAttackOverrideActor<ActiveEffect, SelectedLoadout>,
+  Invocation extends Pick<
+    WeaponAttackOverrideExecutableInvocation,
+    "activeEffect"
+  >,
+  ActiveDruidWildShape,
+>(
+  actor: Actor,
+  invocation: Invocation,
+  runtime: WeaponAttackOverrideUsabilityRuntime<
+    Actor,
+    SelectedLoadout,
+    ActiveDruidWildShape
+  >,
+): boolean {
+  return (
+    actor.origin.kind === "character" &&
+    runtime.loadoutWeaponItemIsUsableDuringWildShape({
+      loadout: actor.origin.selectedLoadout,
+      activeWildShape: runtime.activeDruidWildShapeEffect(actor),
+      itemId: invocation.activeEffect.weaponItemId,
+    })
+  );
+}
+
+export function discoverWeaponAttackOverrideCastAct<
+  SelectedLoadout,
+  Actor extends WeaponAttackOverrideActor<
+    BattleActiveEffectIdentity,
+    SelectedLoadout
+  >,
+  State extends WeaponAttackOverrideBattleState<Actor>,
+  Invocation extends WeaponAttackOverrideExecutableInvocation,
+  ActiveDruidWildShape,
+>(
+  state: State & WeaponAttackOverrideBattleState<Actor>,
+  actorId: CombatantId,
+  invocation: Invocation,
+  runtime: WeaponAttackOverrideUsabilityRuntime<
+    Actor,
+    SelectedLoadout,
+    ActiveDruidWildShape
+  >,
+): readonly WeaponAttackOverrideDiscoveryCandidate[] {
+  const actor = state.combatants.get(actorId);
+  if (
+    actor === undefined ||
+    !weaponAttackOverrideWeaponIsUsable(actor, invocation, runtime)
+  ) {
+    return [];
+  }
+  return [
+    {
+      subject: {
+        tag: "bonusActionSpell",
+        actorId,
+        procedureRef: invocation.sourceProcedureRef,
+        mode: { tag: "cast" },
+      },
+      initialHoles: [],
+    },
+  ];
+}
+
+export function resolveWeaponAttackOverride<
+  SelectedLoadout,
+  Actor extends WeaponAttackOverrideActor<
+    BattleActiveEffectIdentity,
+    SelectedLoadout
+  >,
+  State extends WeaponAttackOverrideBattleState<Actor>,
+  Invocation extends WeaponAttackOverrideExecutableInvocation,
+  Fill extends WeaponAttackOverrideFill,
+  ReactionSpellTargetFact,
+  FillSet extends WeaponAttackOverrideFillSet<ReactionSpellTargetFact>,
+  HandledInterruptTrigger,
+  InterruptFrame,
+  Snapshot,
+  InterruptResult extends WeaponAttackOverrideInterruptResult<State, Snapshot>,
+  ResourceInvalidResult extends
+    WeaponAttackOverrideSharedInvalidResult<Snapshot>,
+  ActiveDruidWildShape,
+>(
+  input: {
+    readonly input: {
+      readonly state: State & WeaponAttackOverrideBattleState<Actor>;
+      readonly subject: WeaponAttackOverrideSubject;
+      readonly fills: readonly Fill[];
+      readonly handledInterruptTrigger?: HandledInterruptTrigger | undefined;
+    };
+    readonly actorId: CombatantId;
+    readonly invocation: Invocation;
+    readonly fillSet: FillSet;
+  },
+  runtime: {
+    readonly snapshot: (state: State) => Snapshot;
+    readonly activeDruidWildShapeEffect: (actor: Actor) => ActiveDruidWildShape;
+    readonly loadoutWeaponItemIsUsableDuringWildShape: (input: {
+      readonly loadout: SelectedLoadout;
+      readonly activeWildShape: ActiveDruidWildShape;
+      readonly itemId: BattleObjectId;
+    }) => boolean;
+    readonly spellCastInterruptFrame: (input: {
+      readonly casterId: CombatantId;
+      readonly invocation: Invocation;
+      readonly targetIds: readonly CombatantId[];
+      readonly reactionSpellTargetFacts: readonly ReactionSpellTargetFact[];
+      readonly castingResource: { readonly kind: "bonusAction" };
+      readonly continuation: {
+        readonly kind: "replay";
+        readonly subject: WeaponAttackOverrideSubject;
+        readonly fills: readonly Fill[];
+      };
+    }) => InterruptFrame;
+    readonly maybeOpenInterruptWindow: (
+      state: State,
+      frame: InterruptFrame,
+      handledInterruptTrigger: HandledInterruptTrigger | undefined,
+    ) => InterruptResult | null;
+    readonly replaceActorActiveEffects: (
+      state: State,
+      actorId: CombatantId,
+      actor: Actor,
+      activeEffects: readonly (
+        | Actor["activeEffects"][number]
+        | SpellWeaponAttackOverrideEffect
+      )[],
+    ) => State;
+    readonly spendSpellCastResources: (input: {
+      readonly state: State;
+      readonly actorId: CombatantId;
+      readonly invocation: Invocation;
+      readonly errorState: State;
+    }) => WeaponAttackOverrideResourceSpendResult<State, ResourceInvalidResult>;
+  },
+):
+  | WeaponAttackOverrideInvalidResult<Snapshot>
+  | WeaponAttackOverrideResolvedResult<State, Snapshot>
+  | ResourceInvalidResult
+  | InterruptResult {
+  const invalid = (
+    reason: WeaponAttackOverrideInvalidResult<Snapshot>["reason"],
+    message: string,
+  ): WeaponAttackOverrideInvalidResult<Snapshot> => ({
+    tag: "invalid",
+    reason,
+    message,
+    snapshot: runtime.snapshot(input.input.state),
+  });
+
+  if (weaponAttackOverrideFillsHaveDisallowedFill(input.input.fills)) {
+    return invalid(
+      "invalidFill",
+      "Weapon attack override spells do not use target, roll, damage, or save fills.",
+    );
+  }
+  if (input.invocation.activeEffect.sourceCombatantId !== input.actorId) {
+    return invalid(
+      "unsupportedSubject",
+      "Weapon attack override source combatant does not match the caster.",
+    );
+  }
+  const actor = input.input.state.combatants.get(input.actorId);
+  if (actor === undefined) {
+    return invalid(
+      "missingCombatant",
+      "Weapon attack override caster is not in this battle.",
+    );
+  }
+  if (!weaponAttackOverrideWeaponIsUsable(actor, input.invocation, runtime)) {
+    return invalid(
+      "unsupportedSubject",
+      "Weapon attack override requires its attached weapon to remain usable.",
+    );
+  }
+  const spellCastReactionWindow = runtime.maybeOpenInterruptWindow(
+    input.input.state,
+    runtime.spellCastInterruptFrame({
+      casterId: input.actorId,
+      invocation: input.invocation,
+      targetIds: [input.actorId],
+      reactionSpellTargetFacts: input.fillSet.reactionSpellTargetFacts,
+      castingResource: { kind: "bonusAction" },
+      continuation: {
+        kind: "replay",
+        subject: input.input.subject,
+        fills: input.input.fills,
+      },
+    }),
+    input.input.handledInterruptTrigger,
+  );
+  if (spellCastReactionWindow !== null) {
+    return spellCastReactionWindow;
+  }
+
+  const activeEffects = activeEffectsAfterWeaponAttackOverride(
+    actor.activeEffects,
+    input.invocation.sourceProcedureRef,
+    input.invocation.activeEffect,
+  );
+  const effected = runtime.replaceActorActiveEffects(
+    input.input.state,
+    input.actorId,
+    actor,
+    activeEffects,
+  );
+  const resourced = runtime.spendSpellCastResources({
+    state: effected,
+    actorId: input.actorId,
+    invocation: input.invocation,
+    errorState: input.input.state,
+  });
+  return resourced.tag === "invalid"
+    ? resourced
+    : {
+        tag: "resolved",
+        state: resourced.state,
+        snapshot: runtime.snapshot(resourced.state),
+      };
+}
+
+function weaponAttackOverrideFillsHaveDisallowedFill(
+  fills: readonly WeaponAttackOverrideFill[],
+): boolean {
+  return fills.some(
+    (fill) =>
+      fill.kind !== "targetSpatialFacts" ||
+      fill.holeId !== SPELL_CAST_REACTION_FACTS_HOLE_ID,
+  );
+}
 
 function exactSchema<Expected>() {
   return <Encoded, Context, Actual extends Expected>(

--- a/packages/battle-runtime/src/unit-profile-admission-slow-active-penalties.test.ts
+++ b/packages/battle-runtime/src/unit-profile-admission-slow-active-penalties.test.ts
@@ -13,7 +13,11 @@ import {
   canSpendAction,
   canSpendBonusAction,
 } from "@dnd/shared-algebras/action-economy-algebra";
-import { currentArmorClass } from "@dnd/shared-algebras/armor-class-algebra";
+import {
+  abilityModifier,
+  currentArmorClass,
+} from "@dnd/shared-algebras/armor-class-algebra";
+import { proficiencyBonus } from "@dnd/shared/types";
 import { describe, expect, test } from "vitest";
 import {
   activeEffectArmorClass,
@@ -68,6 +72,7 @@ import {
 } from "./battle-runtime-test-support.ts";
 import { spellBattle } from "./unit-profile-admission-spell-battle-support.ts";
 import { spellRecord } from "./unit-profile-admission-spell-record-support.ts";
+import { shillelaghUnitId } from "./unit-profile-admission-catalog-support.ts";
 import { defineSelectedIdentityReplayWitness } from "./selected-identity-witness.ts";
 
 const slowExtraTargetId = combatantId("unit-profile-slow-extra-target");
@@ -564,6 +569,62 @@ describe("Task 12 deterministic Slow active-penalties admission", () => {
       kind: "committed",
       combatantId: spellTargetId,
     });
+  });
+
+  test("a successful Slow Somatic outcome continues a Shillelagh cast", () => {
+    const targetTurn = targetTurnAfterFailedSlow(
+      spellBattle({
+        preparedSpells: [spellRecord(slowUnitId)],
+        spellSlots: [{ spellLevel: 3, count: 1 }],
+        targetAttack: zeroAbilityWeaponAttack("weapon_quarterstaff"),
+        targetClassLevels: [{ className: "druid", level: 1 }],
+        targetSpellcasting: {
+          sourceClassName: "druid",
+          spellcastingAbilityModifier: abilityModifier(3),
+          proficiencyBonus: proficiencyBonus(2),
+          canCastSpells: true,
+          cantrips: [spellRecord(shillelaghUnitId)],
+          preparedSpells: [],
+          featurePreparedSpells: [],
+          spellbookRitualSpellAccesses: [],
+          invocationSpellAccesses: [],
+          spellSlots: [],
+        },
+      }),
+    );
+    const act = spellActForActor(targetTurn, spellTargetId, shillelaghUnitId);
+    const slowChance = requireSlowSomaticSpellFailureHole(act.initialHoles);
+
+    expect(
+      resolveBattleSubject({
+        state: targetTurn.state,
+        subject: act.subject,
+        fills: [
+          slowSomaticSpellFailureFill(slowChance, true),
+          {
+            kind: "targetChoice",
+            holeId: slowChance.holeId,
+            value: spellCasterId,
+          },
+        ],
+      }),
+    ).toMatchObject({ tag: "invalid", reason: "invalidFill" });
+
+    const resolved = resolveBattleSubject({
+      state: targetTurn.state,
+      subject: act.subject,
+      fills: [slowSomaticSpellFailureFill(slowChance, false)],
+    });
+
+    expect(resolved).toMatchObject({ tag: "resolved" });
+    if (resolved.tag !== "resolved") {
+      throw new Error("Expected slowed Shillelagh to resolve after success.");
+    }
+    expect(
+      requireCombatant(resolved.state, spellTargetId).activeEffects,
+    ).toContainEqual(
+      expect.objectContaining({ kind: "spellWeaponAttackOverride" }),
+    );
   });
 
   test("slowed spell cast without an effective Somatic component does not ask for the Slow chance outcome", () => {

--- a/packages/battle-runtime/src/unit-profile-admission-spell-battle-support.ts
+++ b/packages/battle-runtime/src/unit-profile-admission-spell-battle-support.ts
@@ -86,6 +86,10 @@ export function spellBattle(input: {
     BattleCreatureInit["creatureInit"],
     { readonly kind: "character" }
   >["unitFeatures"];
+  readonly targetClassLevels?: Extract<
+    BattleCreatureInit["creatureInit"],
+    { readonly kind: "character" }
+  >["classLevels"];
   readonly targetSpellcasting?: Extract<
     BattleCreatureInit["creatureInit"],
     { readonly kind: "character" }
@@ -195,6 +199,9 @@ export function spellBattle(input: {
               ...(input.targetUnitFeatures === undefined
                 ? {}
                 : { unitFeatures: input.targetUnitFeatures }),
+              ...(input.targetClassLevels === undefined
+                ? {}
+                : { classLevels: input.targetClassLevels }),
               ...(input.targetSpellcasting === undefined &&
               input.targetPreparedSpells === undefined
                 ? {}

--- a/packages/battle-runtime/src/unit-profile-admission-weapon-override-and-rider-spells.test.ts
+++ b/packages/battle-runtime/src/unit-profile-admission-weapon-override-and-rider-spells.test.ts
@@ -7,7 +7,10 @@ import {
 } from "./battle-act-composition.ts";
 import { battleRuntimeContextFromCharacterAdmission } from "./battle-runtime-context.ts";
 import { requireCharacterSpellProcedureRefForTest } from "./battle-runtime-test-support.ts";
-import { ATTACK_TARGET_HOLE_ID } from "./battle-reducer/battle-runtime-protocol.ts";
+import {
+  ATTACK_TARGET_HOLE_ID,
+  SPELL_CAST_REACTION_FACTS_HOLE_ID,
+} from "./battle-reducer/battle-runtime-protocol.ts";
 // KERNEL-COVERAGE: parity-witness BATTLE.SPELL.WEAPON_HOSTED_ATTACK_AND_RIDERS
 // UNIT-IDENTITY-EVIDENCE: deterministic-admission-projection SRDINV84H shillelagh
 // UNIT-IDENTITY-EVIDENCE: deterministic-admission-projection SRDINV31A divine_favor
@@ -184,6 +187,32 @@ describe("SRDINV84H deterministic Shillelagh weapon override admission", () => {
       message:
         "Weapon attack override spells do not use target, roll, damage, or save fills.",
     });
+  });
+
+  test("shillelagh accepts spell-cast Reaction facts", () => {
+    const session = spellBattle({
+      cantrips: [spellRecord(shillelaghUnitId)],
+      attack: zeroAbilityWeaponAttack("weapon_quarterstaff"),
+      casterClassLevels: [{ className: "druid", level: 1 }],
+    });
+    const act = bonusSpellAct({
+      session,
+      spellId: shillelaghUnitId,
+    });
+
+    expect(
+      resolveBattleSubject({
+        state: session.state,
+        subject: act.subject,
+        fills: [
+          {
+            kind: "targetSpatialFacts",
+            holeId: SPELL_CAST_REACTION_FACTS_HOLE_ID,
+            spatialFacts: [],
+          },
+        ],
+      }),
+    ).toMatchObject({ tag: "resolved" });
   });
 
   test("presentation rejects a context invocation that contradicts committed execution", () => {

--- a/packages/battle-runtime/src/unit-profile-admission-weapon-override-and-rider-spells.test.ts
+++ b/packages/battle-runtime/src/unit-profile-admission-weapon-override-and-rider-spells.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./battle-act-composition.ts";
 import { battleRuntimeContextFromCharacterAdmission } from "./battle-runtime-context.ts";
 import { requireCharacterSpellProcedureRefForTest } from "./battle-runtime-test-support.ts";
+import { ATTACK_TARGET_HOLE_ID } from "./battle-reducer/battle-runtime-protocol.ts";
 // KERNEL-COVERAGE: parity-witness BATTLE.SPELL.WEAPON_HOSTED_ATTACK_AND_RIDERS
 // UNIT-IDENTITY-EVIDENCE: deterministic-admission-projection SRDINV84H shillelagh
 // UNIT-IDENTITY-EVIDENCE: deterministic-admission-projection SRDINV31A divine_favor
@@ -152,6 +153,37 @@ describe("SRDINV84H deterministic Shillelagh weapon override admission", () => {
             shillelaghUnitId,
       ),
     ).toBe(false);
+  });
+
+  test("shillelagh rejects fills other than spell-cast Reaction facts", () => {
+    const session = spellBattle({
+      cantrips: [spellRecord(shillelaghUnitId)],
+      attack: zeroAbilityWeaponAttack("weapon_quarterstaff"),
+      casterClassLevels: [{ className: "druid", level: 1 }],
+    });
+    const act = bonusSpellAct({
+      session,
+      spellId: shillelaghUnitId,
+    });
+
+    expect(
+      resolveBattleSubject({
+        state: session.state,
+        subject: act.subject,
+        fills: [
+          {
+            kind: "targetChoice",
+            holeId: ATTACK_TARGET_HOLE_ID,
+            value: spellTargetId,
+          },
+        ],
+      }),
+    ).toMatchObject({
+      tag: "invalid",
+      reason: "invalidFill",
+      message:
+        "Weapon attack override spells do not use target, roll, damage, or save fills.",
+    });
   });
 
   test("presentation rejects a context invocation that contradicts committed execution", () => {

--- a/packages/battle-runtime/src/unit-profile-admission-weapon-override-and-rider-spells.test.ts
+++ b/packages/battle-runtime/src/unit-profile-admission-weapon-override-and-rider-spells.test.ts
@@ -18,6 +18,7 @@ import {
 // UNIT-PROFILE-COVERAGE: verification-owner:runtime-test spell.invocation-weapon-attack-override spell.invocation-weapon-damage-rider spell.invocation-magic-weapon-enhancement
 import { describe, expect, test } from "vitest";
 import {
+  counterspellUnitId,
   divineFavorDurationTicks,
   divineFavorUnitId,
   magicWeaponDurationTicks,
@@ -57,6 +58,8 @@ import {
   discoverBattleActs,
   elapsedTimeTicks,
   endTurn,
+  movementFeet,
+  proficiencyBonus,
   resolveBattleSubject,
   spellSlotInvocationRef,
 } from "./unit-profile-admission-test-support.ts";
@@ -213,6 +216,70 @@ describe("SRDINV84H deterministic Shillelagh weapon override admission", () => {
         ],
       }),
     ).toMatchObject({ tag: "resolved" });
+  });
+
+  test("shillelagh waits for a populated spell-cast Reaction window before committing", () => {
+    const session = spellBattle({
+      cantrips: [spellRecord(shillelaghUnitId)],
+      attack: zeroAbilityWeaponAttack("weapon_quarterstaff"),
+      casterClassLevels: [{ className: "druid", level: 1 }],
+      targetSpellcasting: {
+        sourceClassName: "wizard",
+        spellcastingAbilityModifier: abilityModifier(3),
+        proficiencyBonus: proficiencyBonus(2),
+        canCastSpells: true,
+        cantrips: [],
+        preparedSpells: [spellRecord(counterspellUnitId)],
+        featurePreparedSpells: [],
+        spellbookRitualSpellAccesses: [],
+        invocationSpellAccesses: [],
+        spellSlots: [{ spellLevel: 3, count: 1 }],
+      },
+    });
+    const act = bonusSpellAct({
+      session,
+      spellId: shillelaghUnitId,
+    });
+
+    const awaitingReaction = resolveBattleSubject({
+      state: session.state,
+      subject: act.subject,
+      fills: [
+        {
+          kind: "targetSpatialFacts",
+          holeId: SPELL_CAST_REACTION_FACTS_HOLE_ID,
+          spatialFacts: [
+            {
+              kind: "counterspellTriggerCasterVisibleWithinRange",
+              reactorId: spellTargetId,
+              casterId: spellCasterId,
+              sourceProcedureRef: requireCharacterSpellProcedureRefForTest(
+                session,
+                spellTargetId,
+                spellSlotInvocationRef(counterspellUnitId, 3, "counterspell"),
+              ),
+              rangeFeet: movementFeet(60),
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(awaitingReaction).toMatchObject({
+      tag: "needsHoles",
+      snapshot: {
+        pendingInterrupt: { trigger: "spellCast" },
+        turn: { bonusActionAvailable: true },
+      },
+    });
+    if (awaitingReaction.tag !== "needsHoles") {
+      throw new Error("Expected Shillelagh to open a Reaction window.");
+    }
+    expect(
+      requireCombatant(awaitingReaction.state, spellCasterId).activeEffects,
+    ).not.toContainEqual(
+      expect.objectContaining({ kind: "spellWeaponAttackOverride" }),
+    );
   });
 
   test("presentation rejects a context invocation that contradicts committed execution", () => {

--- a/packages/battle-runtime/src/weapon-attack-override-fill-input.test.ts
+++ b/packages/battle-runtime/src/weapon-attack-override-fill-input.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+import type { BattleFill } from "./battle-reducer.ts";
+import {
+  ATTACK_TARGET_HOLE_ID,
+  SPELL_CAST_REACTION_FACTS_HOLE_ID,
+} from "./battle-reducer/battle-runtime-protocol.ts";
+import { parseWeaponAttackOverrideFillInput } from "./battle-reducer/weapon-attack-override-fill-input.ts";
+import { battleProcedureExecutionRefForTest } from "./battle-runtime-test-support.ts";
+import {
+  spellCasterId,
+  spellTargetId,
+} from "./unit-profile-admission-catalog-support.ts";
+import { movementFeet } from "./unit-profile-admission-test-support.ts";
+
+type TargetSpatialFactsFill = Extract<
+  BattleFill,
+  { readonly kind: "targetSpatialFacts" }
+>;
+type CounterspellTriggerFact = Extract<
+  TargetSpatialFactsFill["spatialFacts"][number],
+  { readonly kind: "counterspellTriggerCasterVisibleWithinRange" }
+>;
+
+const counterspellTriggerFact: CounterspellTriggerFact = {
+  kind: "counterspellTriggerCasterVisibleWithinRange",
+  reactorId: spellTargetId,
+  casterId: spellCasterId,
+  sourceProcedureRef: battleProcedureExecutionRefForTest("counterspell"),
+  rangeFeet: movementFeet(60),
+};
+
+function reactionFactsFill(
+  spatialFacts: TargetSpatialFactsFill["spatialFacts"],
+): TargetSpatialFactsFill {
+  return {
+    kind: "targetSpatialFacts",
+    holeId: SPELL_CAST_REACTION_FACTS_HOLE_ID,
+    spatialFacts,
+  };
+}
+
+describe("weapon attack override fill input", () => {
+  test("parses no fills as no spell-cast Reaction facts", () => {
+    expect(parseWeaponAttackOverrideFillInput([])).toEqual({
+      tag: "parsed",
+      input: { reactionFacts: [] },
+    });
+  });
+
+  test("parses one canonical empty spell-cast Reaction facts fill", () => {
+    expect(parseWeaponAttackOverrideFillInput([reactionFactsFill([])])).toEqual(
+      {
+        tag: "parsed",
+        input: { reactionFacts: [] },
+      },
+    );
+  });
+
+  test("projects populated spell-cast Reaction facts", () => {
+    expect(
+      parseWeaponAttackOverrideFillInput([
+        reactionFactsFill([counterspellTriggerFact]),
+      ]),
+    ).toEqual({
+      tag: "parsed",
+      input: { reactionFacts: [counterspellTriggerFact] },
+    });
+  });
+
+  test("rejects the correct fill kind with a noncanonical hole id", () => {
+    expect(
+      parseWeaponAttackOverrideFillInput([
+        {
+          kind: "targetSpatialFacts",
+          holeId: ATTACK_TARGET_HOLE_ID,
+          spatialFacts: [],
+        },
+      ]),
+    ).toMatchObject({ tag: "invalid" });
+  });
+
+  test("rejects a representative non-Reaction fill", () => {
+    expect(
+      parseWeaponAttackOverrideFillInput([
+        {
+          kind: "targetChoice",
+          holeId: ATTACK_TARGET_HOLE_ID,
+          value: spellTargetId,
+        },
+      ]),
+    ).toMatchObject({ tag: "invalid" });
+  });
+
+  test("rejects duplicate canonical spell-cast Reaction facts fills", () => {
+    expect(
+      parseWeaponAttackOverrideFillInput([
+        reactionFactsFill([]),
+        reactionFactsFill([]),
+      ]),
+    ).toMatchObject({ tag: "invalid" });
+  });
+
+  test("rejects malformed spell-cast Reaction facts", () => {
+    expect(
+      parseWeaponAttackOverrideFillInput([
+        reactionFactsFill([
+          {
+            kind: "attackAttackerCannotSeeTarget",
+            attackerId: spellCasterId,
+            targetId: spellTargetId,
+          },
+        ]),
+      ]),
+    ).toMatchObject({ tag: "invalid" });
+  });
+});


### PR DESCRIPTION
Closes #204.

## What changed

- moves weapon-attack-override discovery, fill parsing, interrupt progression, effect commit, and resource spend under the protected execution owner;
- binds subject, caster, invocation, and procedure identity in one validated execution witness;
- introduces a procedure-scoped exhaustive fill parser and explicit checkpoint-failed / interruptions-cleared / non-empty-window progression;
- keeps spell-cast and weapon-attack trigger identities distinct while sharing interrupt transport;
- covers Reaction facts, Slow ordering, cross-trigger handling, identity, and commit authorization with focused regressions;
- formats supported staged workspace files in pre-commit without running broad quality or rewriting generated `pnpm-lock.yaml`.

## Why

#203 established the admission seam. This completes the execution-orchestration extraction needed before #205 can extract durable shared spell/active-effect vocabulary.

## Verification

- focused parser/weapon override/Slow/Counterspell tests: 48/48 passed;
- battle-runtime non-MBT suite: 1710 passed, 47 QNT proof reminders skipped;
- battle-runtime typecheck and formatting passed;
- focused weapon-hosted MBT: 9/9 passed;
- battle-runtime import ownership gate passed;
- guarded root `pnpm quality` passed;
- RAW, ubiquitous-language/domain, architecture/connascence, standards, and spec review converged with no findings.

Guarded root `pnpm test` retains the same four unrelated MCP baseline failures reproduced on the exact base: Adrenaline Rush label, two Steady Aim subject expectations, and Ice Knife's obsolete `spellId` fill field. Battle runtime passes and this branch adds no new root-suite failure.
