### PR TITLE
Derive spell procedure capabilities from canonical execution facts

### DIFF
--- a/packages/battle-runtime/src/battle-reducer/metamagic.ts
+++ b/packages/battle-runtime/src/battle-reducer/metamagic.ts
@@ -20,7 +20,6 @@ import type {
   BattleSpellDamageRerollOption,
   BattleSpellAttackRerollOption,
   BattleState,
-  SupportedSpellInvocation,
 } from "../battle-state-execution.ts";
 import type {
   BattleSubject,
@@ -40,11 +39,10 @@ import type {
 } from "../character-execution.ts";
 import { combatantHasLevelOnePlusSpellCastThisTurn } from "./spell-turn-resources.ts";
 import {
-  registeredSpellProcedureClassification,
-  type RegisteredSpellProcedure,
-  type RegisteredSpellProcedureExecution,
-  type SpellProcedureExecutionRegistry,
-} from "./spell-procedure-profiles/execution-registry.ts";
+  spellExecutionClassForProcedure,
+  spellProcedureHasQuickenedActionCostRewrite,
+  type SpellProcedureWithQuickenedActionCostRewrite,
+} from "./spell-execution-facts.ts";
 import {
   DISTANT_METAMAGIC_EFFECT_KIND,
   distantSpellRangeModifierFact,
@@ -129,24 +127,6 @@ type EmpoweredSpellApplicationFact = CharacterBattleMetamagicOptionFact & {
   readonly effectKind: typeof EMPOWERED_METAMAGIC_EFFECT_KIND;
 };
 
-type QuickenedActionRewriteProcedureDisposition =
-  | "bonusActionRewrite"
-  | "actionSpellResolverNotRewritten"
-  | "notActionSpellCasting";
-
-type QuickenedActionRewriteProcedureDispositions = {
-  readonly [Procedure in RegisteredSpellProcedure]: RegisteredSpellProcedureExecution<Procedure>["metamagicCompatibility"];
-} & Record<
-  SupportedSpellInvocation["procedure"],
-  QuickenedActionRewriteProcedureDisposition
->;
-
-type QuickenedActionRewriteProcedure = {
-  [Procedure in keyof QuickenedActionRewriteProcedureDispositions]: QuickenedActionRewriteProcedureDispositions[Procedure] extends "bonusActionRewrite"
-    ? Procedure
-    : never;
-}[keyof QuickenedActionRewriteProcedureDispositions];
-
 export type SpellMetamagicAdmissionIssue = {
   readonly tag: "spellMetamagicAdmissionIssue";
   readonly message: string;
@@ -164,16 +144,13 @@ type SpellMetamagicSubject = Pick<
   "tag" | "mode" | "metamagic"
 >;
 
-export function admitSpellMetamagicApplications(
-  input: {
-    readonly state: BattleState;
-    readonly actor: BattleCreatureState;
-    readonly actorId: CombatantId;
-    readonly invocation: RuntimeSpellProcedure;
-    readonly subject: SpellMetamagicSubject;
-  },
-  executionRegistry: SpellProcedureExecutionRegistry,
-): SpellMetamagicAdmission {
+export function admitSpellMetamagicApplications(input: {
+  readonly state: BattleState;
+  readonly actor: BattleCreatureState;
+  readonly actorId: CombatantId;
+  readonly invocation: RuntimeSpellProcedure;
+  readonly subject: SpellMetamagicSubject;
+}): SpellMetamagicAdmission {
   const selections = input.subject.metamagic ?? [];
   if (selections.length === 0) {
     return { tag: "ok", applications: [] };
@@ -220,14 +197,11 @@ export function admitSpellMetamagicApplications(
   if (stackingIssue !== null) {
     return metamagicIssue(stackingIssue);
   }
-  const supportIssue = spellMetamagicSupportIssue(
-    {
-      applications: knownApplications,
-      invocation: input.invocation,
-      subject: input.subject,
-    },
-    executionRegistry,
-  );
+  const supportIssue = spellMetamagicSupportIssue({
+    applications: knownApplications,
+    invocation: input.invocation,
+    subject: input.subject,
+  });
   if (supportIssue !== null) {
     return metamagicIssue(supportIssue);
   }
@@ -252,15 +226,12 @@ export function admitSpellMetamagicApplications(
     : metamagicIssue(sorceryPointIssue);
 }
 
-export function actorCanOfferQuickenedSpellMetamagic(
-  input: {
-    readonly state: BattleState;
-    readonly actor: BattleCreatureState;
-    readonly actorId: CombatantId;
-    readonly invocation: RuntimeSpellProcedure;
-  },
-  executionRegistry: SpellProcedureExecutionRegistry,
-): boolean {
+export function actorCanOfferQuickenedSpellMetamagic(input: {
+  readonly state: BattleState;
+  readonly actor: BattleCreatureState;
+  readonly actorId: CombatantId;
+  readonly invocation: RuntimeSpellProcedure;
+}): boolean {
   if (input.actor.origin.kind !== "character") {
     return false;
   }
@@ -273,12 +244,7 @@ export function actorCanOfferQuickenedSpellMetamagic(
   if (!spellInvocationHasMagicActionCastingTime(input.invocation)) {
     return false;
   }
-  if (
-    !spellInvocationSupportsQuickenedActionRewrite(
-      input.invocation,
-      executionRegistry,
-    )
-  ) {
+  if (!spellInvocationSupportsQuickenedActionRewrite(input.invocation)) {
     return false;
   }
   if (!canSpendBonusAction(input.state.currentTurnResources)) {
@@ -646,17 +612,11 @@ export function spellInvocationHasMagicActionCastingTime(
 
 export function spellInvocationSupportsQuickenedActionRewrite(
   invocation: RuntimeSpellProcedure,
-  executionRegistry: SpellProcedureExecutionRegistry,
 ): invocation is Extract<
   SpellProcedureExecution,
-  { readonly procedure: QuickenedActionRewriteProcedure }
+  { readonly procedure: SpellProcedureWithQuickenedActionCostRewrite }
 > {
-  return (
-    quickenedActionRewriteProcedureDisposition(
-      invocation,
-      executionRegistry,
-    ) === "bonusActionRewrite"
-  );
+  return spellProcedureHasQuickenedActionCostRewrite(invocation.procedure);
 }
 
 export function spendSpellMetamagicSorceryPoints(input: {
@@ -739,14 +699,11 @@ function metamagicStackingIssue(
     : "A spell can use only one Metamagic option unless one selected option explicitly combines with a different Metamagic option.";
 }
 
-function spellMetamagicSupportIssue(
-  input: {
-    readonly applications: readonly SpellMetamagicApplicationFact[];
-    readonly invocation: RuntimeSpellProcedure;
-    readonly subject: Pick<SpellMetamagicSubject, "tag" | "mode">;
-  },
-  executionRegistry: SpellProcedureExecutionRegistry,
-): string | null {
+function spellMetamagicSupportIssue(input: {
+  readonly applications: readonly SpellMetamagicApplicationFact[];
+  readonly invocation: RuntimeSpellProcedure;
+  readonly subject: Pick<SpellMetamagicSubject, "tag" | "mode">;
+}): string | null {
   const effectKinds = new Set(
     input.applications.map((option) => option.effectKind),
   );
@@ -761,7 +718,6 @@ function spellMetamagicSupportIssue(
     }
     const quickenedSupportIssue = quickenedActionRewriteSupportIssue(
       input.invocation,
-      executionRegistry,
     );
     if (quickenedSupportIssue !== null) {
       return quickenedSupportIssue;
@@ -803,28 +759,14 @@ function spellMetamagicSupportIssue(
   });
 }
 
-function quickenedActionRewriteProcedureDisposition(
-  invocation: RuntimeSpellProcedure,
-  executionRegistry: SpellProcedureExecutionRegistry,
-): QuickenedActionRewriteProcedureDisposition {
-  return registeredSpellProcedureClassification(
-    executionRegistry,
-    invocation.procedure,
-  ).metamagicCompatibility;
-}
-
 function quickenedActionRewriteSupportIssue(
   invocation: RuntimeSpellProcedure,
-  executionRegistry: SpellProcedureExecutionRegistry,
 ): string | null {
-  const disposition = quickenedActionRewriteProcedureDisposition(
-    invocation,
-    executionRegistry,
-  );
-  if (disposition === "bonusActionRewrite") {
+  if (spellProcedureHasQuickenedActionCostRewrite(invocation.procedure)) {
     return null;
   }
-  if (disposition === "actionSpellResolverNotRewritten") {
+  const executionClass = spellExecutionClassForProcedure(invocation.procedure);
+  if (executionClass === "actionCast" || executionClass === "actionCostCast") {
     return QUICKENED_ACTION_SPELL_PROCEDURE_UNSUPPORTED_MESSAGE;
   }
   return QUICKENED_ACTION_CASTING_TIME_REQUIRED_MESSAGE;

--- a/packages/battle-runtime/src/battle-reducer/spell-execution-facts.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-execution-facts.ts
@@ -6,6 +6,7 @@ import type {
 import type {
   RuntimeSpellProcedureExecution,
   SpellProcedureExecution,
+  SpellProcedureExecutionByProcedure,
 } from "../character-execution.ts";
 import { spellInvocationIsSpellcasting } from "./spell-turn-resources.ts";
 import { isTriggeredReactionSpellInvocation } from "./spell-interrupt-procedure-kinds.ts";
@@ -27,105 +28,385 @@ export const SpellExecutionFactsSchema = Schema.Union(
 );
 export type SpellExecutionFacts = typeof SpellExecutionFactsSchema.Type;
 
-const SPELL_EXECUTION_CLASSES = [
-  "actionCast",
-  "actionCostCast",
-  "bonusActionCast",
-  "bonusActionDash",
-  "triggeredReactionOrActionCast",
-  "attackHitBonusAction",
-] as const;
-export type SpellExecutionClass = (typeof SPELL_EXECUTION_CLASSES)[number];
+type ActionSpellProcedureResolutionExecutionFacts =
+  | {
+      readonly acceptsMetamagicApplications: true;
+      readonly acceptsActionCostOverride: true;
+      readonly quickenedActionCostRewrite?: true;
+      readonly sharedSpellAttackDamageBody?: "profileDelegated";
+    }
+  | {
+      readonly acceptsMetamagicApplications: true;
+      readonly sharedSpellAttackDamageBody?: "profileDelegated";
+    };
 
-const SPELL_EXECUTION_CLASS_BY_PROCEDURE = {
-  abilityD20TestRollModeSaveGate: "actionCast",
-  afterHitDamage: "attackHitBonusAction",
-  afterHitDamageAndIllumination: "attackHitBonusAction",
-  afterHitSaveGatedCondition: "attackHitBonusAction",
-  afterHitTimedDamageAndSave: "attackHitBonusAction",
-  antimagicFieldOngoingSpellSuppression: "actionCast",
-  attackBurstSaveDamage: "actionCast",
-  blurAttackRollDefense: "actionCast",
-  chainedSpellAttackDamage: "actionCast",
-  chosenDamageResistance: "actionCast",
-  cloudkillAreaHazard: "actionCast",
-  command: "actionCast",
-  conditionImmunityAndTurnStartTemporaryHitPoints: "actionCast",
-  conditionRemovalProtection: "actionCast",
-  counterspell: "triggeredReactionOrActionCast",
-  creatureSizeDecrease: "actionCast",
-  creatureSizeIncrease: "actionCast",
-  creatureTypeProtection: "actionCast",
-  damageReduction: "actionCast",
-  dancingLightsCombinedCast: "actionCast",
-  dancingLightsReposition: "bonusActionCast",
-  dancingLightsSeparateCast: "actionCast",
-  directCondition: "actionCast",
-  directConditionRemoval: "bonusActionCast",
-  directHitPointRestoration: "actionCostCast",
-  dragonsBreathInitial: "actionCast",
-  expeditiousRetreatDash: "bonusActionDash",
-  featherFallMitigation: "triggeredReactionOrActionCast",
-  flamingSphere: "actionCast",
-  fogCloudObscurement: "actionCast",
-  greaseGroundHazard: "actionCast",
-  gustOfWindLine: "actionCast",
-  hastePositive: "actionCast",
-  heldLight: "bonusActionCast",
-  heldLightHurl: "actionCast",
-  hideousLaughter: "actionCast",
-  hypnoticPattern: "actionCast",
-  insectPlagueAreaHazard: "actionCast",
-  jumpMovementReplacement: "bonusActionCast",
-  levitatedCreature: "actionCast",
-  magicWeaponEnhancement: "bonusActionCast",
-  magicalDarknessPointOrigin: "actionCast",
-  makeStable: "actionCast",
-  markedDamageRider: "bonusActionCast",
-  mirrorImageHitInterception: "actionCast",
-  moonbeam: "actionCast",
-  objectContactDamage: "actionCast",
-  objectContactDamageRepeat: "bonusActionCast",
-  objectLight: "actionCast",
-  ongoingSpellEnd: "actionCast",
-  persistentArmorEffect: "actionCast",
-  repeatedDamageAllocation: "actionCast",
-  rollModifier: "actionCast",
-  sanctuaryTargetingInterdiction: "bonusActionCast",
-  saveGatedAttackRollAdvantage: "actionCast",
-  saveGatedCondition: "actionCast",
-  saveGatedConditionImmunity: "actionCast",
-  saveGatedDamage: "triggeredReactionOrActionCast",
-  scalarBuff: "actionCostCast",
-  seeInvisibleObserverSight: "actionCast",
-  selfTeleport: "bonusActionCast",
-  selfTransformationMode: "actionCast",
-  shieldReaction: "triggeredReactionOrActionCast",
-  sleepTargetAdmission: "actionCast",
-  sleetStormAreaHazard: "actionCast",
-  slowActivePenalties: "actionCast",
-  spellAttackDamage: "actionCast",
-  spellAttackSequence: "actionCast",
-  spellCreatedHeldObject: "bonusActionCast",
-  spellCreatedHeldObjectAttack: "actionCast",
-  spellCreatedHeldObjectReEvoke: "bonusActionCast",
-  spellHostedWeaponAttack: "actionCast",
-  spikeGrowthMovementHazard: "actionCast",
-  spiritualWeaponAttackProxy: "bonusActionCast",
-  spiritualWeaponRepeatAttack: "bonusActionCast",
-  thaumaturgyBoomingVoice: "actionCast",
-  wardingBond: "actionCast",
-  weaponAttackOverride: "bonusActionCast",
-  weaponDamageRider: "bonusActionCast",
-  webRestraintHazard: "actionCast",
-} as const satisfies Record<
-  SupportedSpellInvocation["procedure"],
-  SpellExecutionClass
+type ActionSpellExecutionClassFact =
+  | "actionCast"
+  | "actionCostCast"
+  | "triggeredReactionOrActionCast";
+
+type NonActionSpellExecutionClassFact =
+  | "bonusActionCast"
+  | "bonusActionDash"
+  | "attackHitBonusAction";
+
+type ActionSpellProcedureExecutionFacts = {
+  readonly executionClass: ActionSpellExecutionClassFact;
+  readonly resolution?: ActionSpellProcedureResolutionExecutionFacts;
+};
+
+type BonusActionSpellProcedureExecutionFacts = {
+  readonly executionClass: "bonusActionCast";
+  readonly resolution?: {
+    readonly sharedSpellAttackDamageBody: "direct";
+  };
+};
+
+type NonMagicActionSpellProcedureExecutionFacts =
+  | BonusActionSpellProcedureExecutionFacts
+  | {
+      readonly executionClass: Exclude<
+        NonActionSpellExecutionClassFact,
+        "bonusActionCast"
+      >;
+      readonly resolution?: never;
+    };
+
+type SpellProcedureExecutionFacts =
+  | ActionSpellProcedureExecutionFacts
+  | NonMagicActionSpellProcedureExecutionFacts;
+
+export type SpellProcedureExecutionsWithActionCost<
+  P extends SupportedSpellInvocation["procedure"],
+> = Extract<
+  SpellProcedureExecutionByProcedure[P],
+  { readonly actionCost: unknown }
 >;
+
+export type SpellProcedureExecutionsWithoutActionCost<
+  P extends SupportedSpellInvocation["procedure"],
+> = Exclude<
+  SpellProcedureExecutionByProcedure[P],
+  { readonly actionCost: unknown }
+>;
+
+type ActionCostOf<Execution> = Execution extends {
+  readonly actionCost: infer ActionCost;
+}
+  ? ActionCost
+  : never;
+
+export type SpellProcedureActionCost<
+  P extends SupportedSpellInvocation["procedure"],
+> = ActionCostOf<SpellProcedureExecutionsWithActionCost<P>>;
+
+type SpellProcedureExecutionFactsForProcedure<
+  P extends SupportedSpellInvocation["procedure"],
+> = [SpellProcedureExecutionsWithActionCost<P>] extends [never]
+  ? SpellProcedureExecutionFacts
+  : [
+        Exclude<SpellProcedureActionCost<P>, "magicAction" | "bonusAction">,
+      ] extends [never]
+    ? [Extract<SpellProcedureActionCost<P>, "magicAction">] extends [never]
+      ? [Extract<SpellProcedureActionCost<P>, "bonusAction">] extends [never]
+        ? never
+        : NonMagicActionSpellProcedureExecutionFacts
+      : [Extract<SpellProcedureActionCost<P>, "bonusAction">] extends [never]
+        ? ActionSpellProcedureExecutionFacts
+        : ActionSpellProcedureExecutionFacts & {
+            readonly executionClass: "actionCostCast";
+          }
+    : never;
+
+const METAMAGIC_APPLICATION_RESOLUTION = {
+  acceptsMetamagicApplications: true,
+} as const;
+const ACTION_COST_OVERRIDE_RESOLUTION = {
+  ...METAMAGIC_APPLICATION_RESOLUTION,
+  acceptsActionCostOverride: true,
+} as const;
+const QUICKENED_ACTION_COST_REWRITE_RESOLUTION = {
+  ...ACTION_COST_OVERRIDE_RESOLUTION,
+  quickenedActionCostRewrite: true,
+} as const;
+const PROFILE_DELEGATED_SPELL_ATTACK_DAMAGE_RESOLUTION = {
+  sharedSpellAttackDamageBody: "profileDelegated",
+} as const;
+const SHARED_SPELL_ATTACK_ACTION_COST_OVERRIDE_RESOLUTION = {
+  ...ACTION_COST_OVERRIDE_RESOLUTION,
+  ...PROFILE_DELEGATED_SPELL_ATTACK_DAMAGE_RESOLUTION,
+} as const;
+const SHARED_SPELL_ATTACK_QUICKENED_ACTION_COST_REWRITE_RESOLUTION = {
+  ...QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  ...PROFILE_DELEGATED_SPELL_ATTACK_DAMAGE_RESOLUTION,
+} as const;
+const DIRECT_SPELL_ATTACK_DAMAGE_RESOLUTION = {
+  sharedSpellAttackDamageBody: "direct",
+} as const;
+
+const SPELL_EXECUTION_FACTS_BY_PROCEDURE = {
+  abilityD20TestRollModeSaveGate: { executionClass: "actionCast" },
+  afterHitDamage: { executionClass: "attackHitBonusAction" },
+  afterHitDamageAndIllumination: { executionClass: "attackHitBonusAction" },
+  afterHitSaveGatedCondition: { executionClass: "attackHitBonusAction" },
+  afterHitTimedDamageAndSave: { executionClass: "attackHitBonusAction" },
+  antimagicFieldOngoingSpellSuppression: { executionClass: "actionCast" },
+  attackBurstSaveDamage: {
+    executionClass: "actionCast",
+    resolution: ACTION_COST_OVERRIDE_RESOLUTION,
+  },
+  blurAttackRollDefense: { executionClass: "actionCast" },
+  chainedSpellAttackDamage: {
+    executionClass: "actionCast",
+    resolution: ACTION_COST_OVERRIDE_RESOLUTION,
+  },
+  chosenDamageResistance: { executionClass: "actionCast" },
+  cloudkillAreaHazard: { executionClass: "actionCast" },
+  command: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  conditionImmunityAndTurnStartTemporaryHitPoints: {
+    executionClass: "actionCast",
+  },
+  conditionRemovalProtection: { executionClass: "actionCast" },
+  counterspell: { executionClass: "triggeredReactionOrActionCast" },
+  creatureSizeDecrease: {
+    executionClass: "actionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  creatureSizeIncrease: {
+    executionClass: "actionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  creatureTypeProtection: { executionClass: "actionCast" },
+  damageReduction: { executionClass: "actionCast" },
+  dancingLightsCombinedCast: { executionClass: "actionCast" },
+  dancingLightsReposition: { executionClass: "bonusActionCast" },
+  dancingLightsSeparateCast: { executionClass: "actionCast" },
+  directCondition: {
+    executionClass: "actionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  directConditionRemoval: { executionClass: "bonusActionCast" },
+  directHitPointRestoration: {
+    executionClass: "actionCostCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  dragonsBreathInitial: { executionClass: "bonusActionCast" },
+  expeditiousRetreatDash: { executionClass: "bonusActionDash" },
+  featherFallMitigation: {
+    executionClass: "triggeredReactionOrActionCast",
+  },
+  flamingSphere: { executionClass: "actionCast" },
+  fogCloudObscurement: { executionClass: "actionCast" },
+  greaseGroundHazard: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  gustOfWindLine: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  hastePositive: { executionClass: "actionCast" },
+  heldLight: { executionClass: "bonusActionCast" },
+  heldLightHurl: {
+    executionClass: "actionCast",
+    resolution: SHARED_SPELL_ATTACK_ACTION_COST_OVERRIDE_RESOLUTION,
+  },
+  hideousLaughter: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  hypnoticPattern: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  insectPlagueAreaHazard: { executionClass: "actionCast" },
+  jumpMovementReplacement: { executionClass: "bonusActionCast" },
+  levitatedCreature: { executionClass: "actionCast" },
+  magicWeaponEnhancement: { executionClass: "bonusActionCast" },
+  magicalDarknessPointOrigin: { executionClass: "actionCast" },
+  makeStable: { executionClass: "actionCast" },
+  markedDamageRider: { executionClass: "bonusActionCast" },
+  mirrorImageHitInterception: { executionClass: "actionCast" },
+  moonbeam: { executionClass: "actionCast" },
+  objectContactDamage: { executionClass: "actionCast" },
+  objectContactDamageRepeat: { executionClass: "bonusActionCast" },
+  objectLight: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  ongoingSpellEnd: { executionClass: "actionCast" },
+  persistentArmorEffect: { executionClass: "actionCast" },
+  repeatedDamageAllocation: { executionClass: "actionCast" },
+  rollModifier: {
+    executionClass: "actionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  sanctuaryTargetingInterdiction: { executionClass: "bonusActionCast" },
+  saveGatedAttackRollAdvantage: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  saveGatedCondition: {
+    executionClass: "actionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  saveGatedConditionImmunity: {
+    executionClass: "actionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  saveGatedDamage: {
+    executionClass: "triggeredReactionOrActionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  scalarBuff: {
+    executionClass: "actionCostCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  seeInvisibleObserverSight: { executionClass: "actionCast" },
+  selfTeleport: { executionClass: "bonusActionCast" },
+  selfTransformationMode: { executionClass: "actionCast" },
+  shieldReaction: { executionClass: "triggeredReactionOrActionCast" },
+  sleepTargetAdmission: { executionClass: "actionCast" },
+  sleetStormAreaHazard: { executionClass: "actionCast" },
+  slowActivePenalties: {
+    executionClass: "actionCast",
+    resolution: METAMAGIC_APPLICATION_RESOLUTION,
+  },
+  spellAttackDamage: {
+    executionClass: "actionCast",
+    resolution: SHARED_SPELL_ATTACK_QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  spellAttackSequence: {
+    executionClass: "actionCast",
+    resolution: QUICKENED_ACTION_COST_REWRITE_RESOLUTION,
+  },
+  spellCreatedHeldObject: { executionClass: "bonusActionCast" },
+  spellCreatedHeldObjectAttack: {
+    executionClass: "actionCast",
+    resolution: SHARED_SPELL_ATTACK_ACTION_COST_OVERRIDE_RESOLUTION,
+  },
+  spellCreatedHeldObjectReEvoke: { executionClass: "bonusActionCast" },
+  spellHostedWeaponAttack: { executionClass: "actionCast" },
+  spikeGrowthMovementHazard: { executionClass: "actionCast" },
+  spiritualWeaponAttackProxy: {
+    executionClass: "bonusActionCast",
+    resolution: DIRECT_SPELL_ATTACK_DAMAGE_RESOLUTION,
+  },
+  spiritualWeaponRepeatAttack: {
+    executionClass: "bonusActionCast",
+    resolution: DIRECT_SPELL_ATTACK_DAMAGE_RESOLUTION,
+  },
+  thaumaturgyBoomingVoice: { executionClass: "actionCast" },
+  wardingBond: { executionClass: "actionCast" },
+  weaponAttackOverride: { executionClass: "bonusActionCast" },
+  weaponDamageRider: { executionClass: "bonusActionCast" },
+  webRestraintHazard: { executionClass: "actionCast" },
+} as const satisfies {
+  readonly [P in SupportedSpellInvocation["procedure"]]: SpellProcedureExecutionFactsForProcedure<P>;
+};
+
+export type SpellExecutionClass =
+  (typeof SPELL_EXECUTION_FACTS_BY_PROCEDURE)[SupportedSpellInvocation["procedure"]]["executionClass"];
 
 export type SpellExecutionClassForProcedure<
   P extends SupportedSpellInvocation["procedure"],
-> = (typeof SPELL_EXECUTION_CLASS_BY_PROCEDURE)[P];
+> = (typeof SPELL_EXECUTION_FACTS_BY_PROCEDURE)[P]["executionClass"];
+
+type SpellProcedureExecutionFactsByProcedure =
+  typeof SPELL_EXECUTION_FACTS_BY_PROCEDURE;
+
+export type SpellProcedureAcceptingMetamagicApplications = {
+  [P in SupportedSpellInvocation["procedure"]]: SpellProcedureExecutionFactsByProcedure[P] extends {
+    readonly resolution: {
+      readonly acceptsMetamagicApplications: true;
+    };
+  }
+    ? P
+    : never;
+}[SupportedSpellInvocation["procedure"]];
+
+export type SpellProcedureAcceptingActionCostOverride = {
+  [P in SupportedSpellInvocation["procedure"]]: SpellProcedureExecutionFactsByProcedure[P] extends {
+    readonly resolution: {
+      readonly acceptsActionCostOverride: true;
+    };
+  }
+    ? P
+    : never;
+}[SupportedSpellInvocation["procedure"]];
+
+export type SpellProcedureWithQuickenedActionCostRewrite = {
+  [P in SupportedSpellInvocation["procedure"]]: SpellProcedureExecutionFactsByProcedure[P] extends {
+    readonly resolution: {
+      readonly quickenedActionCostRewrite: true;
+    };
+  }
+    ? P
+    : never;
+}[SupportedSpellInvocation["procedure"]];
+
+export type SpellProcedureWithProfileDelegatedSpellAttackDamageBody = {
+  [P in SupportedSpellInvocation["procedure"]]: SpellProcedureExecutionFactsByProcedure[P] extends {
+    readonly resolution: {
+      readonly sharedSpellAttackDamageBody: "profileDelegated";
+    };
+  }
+    ? P
+    : never;
+}[SupportedSpellInvocation["procedure"]];
+
+export function spellProcedureAcceptsMetamagicApplications(
+  procedure: SupportedSpellInvocation["procedure"],
+): procedure is SpellProcedureAcceptingMetamagicApplications {
+  const facts: SpellProcedureExecutionFacts =
+    SPELL_EXECUTION_FACTS_BY_PROCEDURE[procedure];
+  return (
+    facts.resolution !== undefined &&
+    "acceptsMetamagicApplications" in facts.resolution
+  );
+}
+
+export function spellProcedureAcceptsActionCostOverride(
+  procedure: SupportedSpellInvocation["procedure"],
+): procedure is SpellProcedureAcceptingActionCostOverride {
+  const facts: SpellProcedureExecutionFacts =
+    SPELL_EXECUTION_FACTS_BY_PROCEDURE[procedure];
+  return (
+    facts.resolution !== undefined &&
+    "acceptsActionCostOverride" in facts.resolution
+  );
+}
+
+export function spellProcedureHasQuickenedActionCostRewrite(
+  procedure: SupportedSpellInvocation["procedure"],
+): procedure is SpellProcedureWithQuickenedActionCostRewrite {
+  const facts: SpellProcedureExecutionFacts =
+    SPELL_EXECUTION_FACTS_BY_PROCEDURE[procedure];
+  return (
+    facts.resolution !== undefined &&
+    "quickenedActionCostRewrite" in facts.resolution
+  );
+}
+
+export function spellProcedureSharedSpellAttackDamageBodyRouting(
+  procedure: SupportedSpellInvocation["procedure"],
+): "profileDelegated" | "direct" | undefined {
+  const facts: SpellProcedureExecutionFacts =
+    SPELL_EXECUTION_FACTS_BY_PROCEDURE[procedure];
+  return facts.resolution !== undefined &&
+    "sharedSpellAttackDamageBody" in facts.resolution
+    ? facts.resolution.sharedSpellAttackDamageBody
+    : undefined;
+}
+
+export function spellExecutionClassForProcedure(
+  procedure: SupportedSpellInvocation["procedure"],
+): SpellExecutionClass {
+  return SPELL_EXECUTION_FACTS_BY_PROCEDURE[procedure].executionClass;
+}
 
 // ReadiedSpellInvocation is the wider mechanical release-shape union. This
 // list is the single admission boundary for procedures whose reducers are
@@ -158,19 +439,18 @@ export function spellInvocationHasReadiedSpellExecutionShape(
 function executionClassForInvocation(
   invocation: Pick<SupportedSpellInvocation, "procedure">,
 ): SpellExecutionClass {
-  return SPELL_EXECUTION_CLASS_BY_PROCEDURE[invocation.procedure];
+  return spellExecutionClassForProcedure(invocation.procedure);
 }
 
 export function spellSubjectTagForInvocation(
   invocation: SpellProcedureExecution | BattleExecutableSpellInvocation,
 ): "actionSpell" | "bonusActionSpell" {
-  if (
-    invocation.procedure === "directHitPointRestoration" ||
-    invocation.procedure === "scalarBuff"
-  ) {
-    return invocation.actionCost === "bonusAction"
-      ? "bonusActionSpell"
-      : "actionSpell";
+  if ("actionCost" in invocation) {
+    return Match.value(invocation.actionCost).pipe(
+      Match.when("magicAction", () => "actionSpell" as const),
+      Match.when("bonusAction", () => "bonusActionSpell" as const),
+      Match.exhaustive,
+    );
   }
   return Match.value(executionClassForInvocation(invocation)).pipe(
     Match.when("actionCast", () => "actionSpell" as const),
@@ -184,7 +464,7 @@ export function spellSubjectTagForInvocation(
 }
 
 export function spellExecutionFacts(
-  invocation: SpellProcedureExecution,
+  invocation: SpellProcedureExecution | BattleExecutableSpellInvocation,
 ): SpellExecutionFacts {
   const executionClass = executionClassForInvocation(invocation);
   if (

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/ability-d20-test-roll-mode-save-gate.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/ability-d20-test-roll-mode-save-gate.ts
@@ -195,7 +195,6 @@ const AbilityD20TestRollModeSaveGateInvocationSchema =
 export const abilityD20TestRollModeSaveGateProfile = {
   procedure: "abilityD20TestRollModeSaveGate",
   executionSchema: AbilityD20TestRollModeSaveGateInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitAbilityD20TestRollModeSaveGate,
   discoverCastAct: discoverAbilityD20TestRollModeSaveGateCastAct,
   resolve: resolveAbilityD20TestRollModeSaveGate,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-damage-and-illumination.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-damage-and-illumination.ts
@@ -372,7 +372,6 @@ const AfterHitDamageAndIlluminationInvocationSchema =
 export const afterHitDamageAndIlluminationProfile = {
   procedure: "afterHitDamageAndIllumination",
   executionSchema: AfterHitDamageAndIlluminationInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitAfterHitDamageAndIllumination,
   discoverCastAct: discoverAfterHitDamageAndIlluminationCastAct,
   resolve: resolveAfterHitDamageAndIllumination,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-damage.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-damage.ts
@@ -385,7 +385,6 @@ const AfterHitDamageInvocationSchema = spellProcedureExecutionSchema(
 export const afterHitDamageProfile = {
   procedure: "afterHitDamage",
   executionSchema: AfterHitDamageInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitAfterHitDamage,
   discoverCastAct: discoverAfterHitDamageCastAct,
   resolve: resolveAfterHitDamage,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-save-gated-condition.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-save-gated-condition.ts
@@ -479,7 +479,6 @@ const AfterHitSaveGatedConditionInvocationSchema =
 export const afterHitSaveGatedConditionProfile = {
   procedure: "afterHitSaveGatedCondition",
   executionSchema: AfterHitSaveGatedConditionInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitAfterHitSaveGatedCondition,
   discoverCastAct: discoverAfterHitSaveGatedConditionCastAct,
   resolve: resolveAfterHitSaveGatedCondition,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-timed-damage-and-save.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/after-hit-timed-damage-and-save.ts
@@ -394,7 +394,6 @@ const AfterHitTimedDamageAndSaveInvocationSchema =
 export const afterHitTimedDamageAndSaveProfile = {
   procedure: "afterHitTimedDamageAndSave",
   executionSchema: AfterHitTimedDamageAndSaveInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitAfterHitTimedDamageAndSave,
   discoverCastAct: discoverAfterHitTimedDamageAndSaveCastAct,
   resolve: resolveAfterHitTimedDamageAndSave,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/antimagic-field-ongoing-spell-suppression.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/antimagic-field-ongoing-spell-suppression.ts
@@ -380,7 +380,6 @@ const AntimagicFieldOngoingSpellSuppressionInvocationSchema =
 export const antimagicFieldOngoingSpellSuppressionProfile = {
   procedure: "antimagicFieldOngoingSpellSuppression",
   executionSchema: AntimagicFieldOngoingSpellSuppressionInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitAntimagicFieldOngoingSpellSuppression,
   discoverCastAct: discoverAntimagicFieldOngoingSpellSuppressionCastAct,
   resolve: resolveAntimagicFieldOngoingSpellSuppression,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/attack-burst-save-damage.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/attack-burst-save-damage.ts
@@ -148,7 +148,6 @@ export const attackBurstSaveDamageProfile: SpellProcedureDeclaration<
 > = {
   procedure: "attackBurstSaveDamage",
   executionSchema: AttackBurstSaveDamageInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitAttackBurstSaveDamage,
   discoverCastAct: discoverAttackBurstSaveDamageCastAct,
   resolve: resolveAttackBurstSaveDamage,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/blur-attack-roll-defense.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/blur-attack-roll-defense.ts
@@ -278,7 +278,6 @@ export const blurAttackRollDefenseProfile: SpellProcedureDeclaration<
 > = {
   procedure: "blurAttackRollDefense",
   executionSchema: BlurAttackRollDefenseInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitBlurAttackRollDefense,
   discoverCastAct: discoverBlurAttackRollDefenseCastAct,
   resolve: resolveBlurAttackRollDefense,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/chained-spell-attack-damage.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/chained-spell-attack-damage.ts
@@ -132,7 +132,6 @@ export const chainedSpellAttackDamageProfile: SpellProcedureDeclaration<
 > = {
   procedure: "chainedSpellAttackDamage",
   executionSchema: ChainedSpellAttackDamageInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitChainedSpellAttackDamage,
   discoverCastAct: discoverChainedSpellAttackDamageCastAct,
   resolve: resolveChainedSpellAttackDamage,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/chosen-damage-resistance.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/chosen-damage-resistance.ts
@@ -403,7 +403,6 @@ export const chosenDamageResistanceProfile: SpellProcedureDeclaration<
 > = {
   procedure: "chosenDamageResistance",
   executionSchema: ChosenDamageResistanceInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitChosenDamageResistance,
   discoverCastAct: discoverChosenDamageResistanceCastAct,
   resolve: resolveChosenDamageResistance,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/cloudkill-area-hazard.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/cloudkill-area-hazard.ts
@@ -276,7 +276,6 @@ const CloudkillAreaHazardInvocationSchema = spellProcedureExecutionSchema(
 export const cloudkillAreaHazardProfile = {
   procedure: "cloudkillAreaHazard",
   executionSchema: CloudkillAreaHazardInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitCloudkillAreaHazard,
   discoverCastAct: discoverCloudkillAreaHazardCastAct,
   resolve: resolveCloudkillAreaHazard,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/command.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/command.ts
@@ -365,7 +365,6 @@ const CommandInvocationSchema = spellProcedureExecutionSchema(
 export const commandProfile = {
   procedure: "command",
   executionSchema: CommandInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitCommand,
   discoverCastAct: discoverCommandCastAct,
   resolve: resolveCommand,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/condition-immunity-turn-start-temporary-hit-points.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/condition-immunity-turn-start-temporary-hit-points.ts
@@ -477,7 +477,6 @@ export const conditionImmunityAndTurnStartTemporaryHitPointsProfile: SpellProced
   procedure: "conditionImmunityAndTurnStartTemporaryHitPoints",
   executionSchema:
     ConditionImmunityAndTurnStartTemporaryHitPointsInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitConditionImmunityAndTurnStartTemporaryHitPoints,
   discoverCastAct:
     discoverConditionImmunityAndTurnStartTemporaryHitPointsCastAct,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/condition-removal-protection.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/condition-removal-protection.ts
@@ -407,7 +407,6 @@ export const conditionRemovalProtectionProfile: SpellProcedureDeclaration<
 > = {
   procedure: "conditionRemovalProtection",
   executionSchema: ConditionRemovalProtectionInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitConditionRemovalProtection,
   discoverCastAct: discoverConditionRemovalProtectionCastAct,
   resolve: resolveConditionRemovalProtection,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/counterspell.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/counterspell.ts
@@ -373,7 +373,6 @@ const CounterspellInvocationSchema = spellProcedureExecutionSchema(
 export const counterspellProfile = {
   procedure: "counterspell",
   executionSchema: CounterspellInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitCounterspell,
   discoverCastAct: discoverCounterspellCastAct,
   resolve: resolveCounterspell,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/creature-size-change.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/creature-size-change.ts
@@ -734,7 +734,6 @@ export const creatureSizeChangeProfile: SpellProcedureDeclaration<
 > = {
   procedure: "creatureSizeIncrease",
   executionSchema: CreatureSizeIncreaseInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitCreatureSizeChange,
   discoverCastAct: discoverCreatureSizeChangeCastAct,
   resolve: resolveCreatureSizeChange,
@@ -746,7 +745,6 @@ export const creatureSizeDecreaseProfile: SpellProcedureDeclaration<
 > = {
   procedure: "creatureSizeDecrease",
   executionSchema: CreatureSizeDecreaseInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitCreatureSizeDecrease,
   discoverCastAct: discoverCreatureSizeChangeCastAct,
   resolve: resolveCreatureSizeChange,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/creature-type-protection.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/creature-type-protection.ts
@@ -490,7 +490,6 @@ export const creatureTypeProtectionProfile: SpellProcedureDeclaration<
 > = {
   procedure: "creatureTypeProtection",
   executionSchema: CreatureTypeProtectionInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitCreatureTypeProtection,
   discoverCastAct: discoverCreatureTypeProtectionCastAct,
   resolve: resolveCreatureTypeProtection,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/damage-reduction.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/damage-reduction.ts
@@ -353,7 +353,6 @@ export const damageReductionProfile: SpellProcedureDeclaration<
   DamageReductionSpellInvocation
 > = {
   procedure: "damageReduction",
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitDamageReduction,
   discoverCastAct: discoverDamageReductionCastAct,
   executionSchema: DamageReductionInvocationSchema,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/dancing-lights.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/dancing-lights.ts
@@ -387,7 +387,6 @@ export const dancingLightsSeparateCastProfile: SpellProcedureDeclaration<
 > = {
   procedure: "dancingLightsSeparateCast",
   executionSchema: DancingLightsSeparateCastInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitDancingLightsSeparateCast,
   discoverCastAct: discoverDancingLightsCastAct,
   resolve: resolveDancingLightsCast,
@@ -399,7 +398,6 @@ export const dancingLightsCombinedCastProfile: SpellProcedureDeclaration<
 > = {
   procedure: "dancingLightsCombinedCast",
   executionSchema: DancingLightsCombinedCastInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitDancingLightsCombinedCast,
   discoverCastAct: discoverDancingLightsCastAct,
   resolve: resolveDancingLightsCast,
@@ -411,7 +409,6 @@ export const dancingLightsRepositionProfile: SpellProcedureDeclaration<
 > = {
   procedure: "dancingLightsReposition",
   executionSchema: DancingLightsRepositionInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitDancingLightsReposition,
   discoverCastAct: discoverDancingLightsRepositionAct,
   resolve: resolveDancingLightsReposition,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/direct-condition-removal.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/direct-condition-removal.ts
@@ -352,7 +352,6 @@ export const directConditionRemovalProfile: SpellProcedureDeclaration<
 > = {
   procedure: "directConditionRemoval",
   executionSchema: DirectConditionRemovalInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitDirectConditionRemoval,
   discoverCastAct: discoverDirectConditionRemovalCastAct,
   resolve: resolveDirectConditionRemoval,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/direct-condition.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/direct-condition.ts
@@ -342,7 +342,6 @@ export const directConditionProfile: SpellProcedureDeclaration<
 > = {
   procedure: "directCondition",
   executionSchema: DirectConditionInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitDirectCondition,
   discoverCastAct: discoverDirectConditionCastAct,
   resolve: resolveDirectCondition,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/direct-hit-point-restoration.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/direct-hit-point-restoration.ts
@@ -443,7 +443,6 @@ const DirectHitPointRestorationInvocationSchema = spellProcedureExecutionSchema(
 export const directHitPointRestorationProfile = {
   procedure: "directHitPointRestoration",
   executionSchema: DirectHitPointRestorationInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitDirectHitPointRestoration,
   discoverCastAct: discoverDirectHitPointRestorationCastAct,
   resolve: resolveDirectHitPointRestoration,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/dragons-breath-initial.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/dragons-breath-initial.ts
@@ -370,7 +370,6 @@ export const DragonsBreathInitialInvocationSchema =
 export const dragonsBreathInitialProfile = {
   procedure: "dragonsBreathInitial",
   executionSchema: DragonsBreathInitialInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitDragonsBreathInitial,
   discoverCastAct: discoverDragonsBreathInitialCastAct,
   resolve: resolveDragonsBreathInitial,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/execution-profile.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/execution-profile.ts
@@ -11,12 +11,8 @@ import type {
 } from "../../character-execution.ts";
 import type { CombatantId } from "../../identity.ts";
 import type { SpellFillSet } from "../spells-resolve-fill-set.ts";
-import type {
-  SpellProcedureExecutionRegistry,
-  SpellProcedureMetamagicCompatibility,
-} from "./execution-registry.ts";
+import type { SpellProcedureExecutionRegistry } from "./execution-registry.ts";
 import type { SpellProcedureDeclarationResolution } from "./resolution-contract.ts";
-export type { SpellProcedureMetamagicCompatibility } from "./execution-registry.ts";
 
 export type OkSpellFillSet = Extract<SpellFillSet, { readonly tag: "ok" }>;
 
@@ -26,7 +22,6 @@ export type SpellProcedureProfileResolveInput<
 
 export type SpellProcedureExecutionDeclaration<P extends SpellProcedureKey> = {
   readonly procedure: P;
-  readonly metamagicCompatibility: SpellProcedureMetamagicCompatibility;
   readonly discoverCastAct: (
     state: BattleState,
     actorId: CombatantId,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/execution-registry.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/execution-registry.ts
@@ -15,20 +15,11 @@ import type {
 } from "./resolution-contract.ts";
 export type { SpellProcedureExecutionResolution } from "./resolution-contract.ts";
 
-export type SpellProcedureMetamagicCompatibility =
-  | "actionSpellResolverNotRewritten"
-  | "bonusActionRewrite"
-  | "notActionSpellCasting";
-
 export type RegisteredSpellProcedure = SpellProcedureKey;
-
-export type RegisteredSpellProcedureClassification = {
-  readonly metamagicCompatibility: SpellProcedureMetamagicCompatibility;
-};
 
 export type RegisteredSpellProcedureExecution<
   Procedure extends RegisteredSpellProcedure,
-> = RegisteredSpellProcedureClassification & {
+> = {
   readonly procedure: Procedure;
   readonly executionSchema: {
     readonly Type: SpellProcedureExecutionByProcedure[Procedure];
@@ -63,13 +54,6 @@ export function spellProcedureExecutionFor<
   registry: SpellProcedureExecutionRegistry,
   procedure: Procedure,
 ): RegisteredSpellProcedureExecution<Procedure> {
-  return registry.executionFor(procedure);
-}
-
-export function registeredSpellProcedureClassification(
-  registry: SpellProcedureExecutionRegistry,
-  procedure: RegisteredSpellProcedure,
-): RegisteredSpellProcedureClassification {
   return registry.executionFor(procedure);
 }
 

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/expeditious-retreat-dash.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/expeditious-retreat-dash.ts
@@ -346,7 +346,6 @@ const ExpeditiousRetreatDashInvocationSchema = spellProcedureExecutionSchema(
 export const expeditiousRetreatDashProfile = {
   procedure: "expeditiousRetreatDash",
   executionSchema: ExpeditiousRetreatDashInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitExpeditiousRetreatDash,
   discoverCastAct: discoverExpeditiousRetreatDashCastAct,
   resolve: resolveExpeditiousRetreatDash,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/feather-fall-mitigation.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/feather-fall-mitigation.ts
@@ -297,7 +297,6 @@ const FeatherFallMitigationInvocationSchema = spellProcedureExecutionSchema(
 export const featherFallMitigationProfile = {
   procedure: "featherFallMitigation",
   executionSchema: FeatherFallMitigationInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitFeatherFallMitigation,
   discoverCastAct: discoverFeatherFallMitigationCastAct,
   resolve: resolveFeatherFallMitigation,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/flaming-sphere.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/flaming-sphere.ts
@@ -307,7 +307,6 @@ const FlamingSphereInvocationSchema = spellProcedureExecutionSchema(
 export const flamingSphereProfile = {
   procedure: "flamingSphere",
   executionSchema: FlamingSphereInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitFlamingSphere,
   discoverCastAct: discoverFlamingSphereCastAct,
   resolve: resolveFlamingSphere,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/fog-cloud-obscurement.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/fog-cloud-obscurement.ts
@@ -209,7 +209,6 @@ const FogCloudObscurementInvocationSchema = spellProcedureExecutionSchema(
 export const fogCloudObscurementProfile = {
   procedure: "fogCloudObscurement",
   executionSchema: FogCloudObscurementInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitFogCloudObscurement,
   discoverCastAct: discoverFogCloudObscurementCastAct,
   resolve: resolveFogCloudObscurement,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/grease-ground-hazard.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/grease-ground-hazard.ts
@@ -334,7 +334,6 @@ const GreaseGroundHazardInvocationSchema = spellProcedureExecutionSchema(
 export const greaseGroundHazardProfile = {
   procedure: "greaseGroundHazard",
   executionSchema: GreaseGroundHazardInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitGreaseGroundHazard,
   discoverCastAct: discoverGreaseGroundHazardCastAct,
   resolve: resolveGreaseGroundHazard,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/gust-of-wind-line.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/gust-of-wind-line.ts
@@ -390,7 +390,6 @@ const GustOfWindLineInvocationSchema = spellProcedureExecutionSchema(
 export const gustOfWindLineProfile = {
   procedure: "gustOfWindLine",
   executionSchema: GustOfWindLineInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitGustOfWindLine,
   discoverCastAct: discoverGustOfWindLineCastAct,
   resolve: resolveGustOfWindLine,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/haste-positive.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/haste-positive.ts
@@ -645,7 +645,6 @@ const HastePositiveInvocationSchema = spellProcedureExecutionSchema(
 export const hastePositiveProfile = {
   procedure: "hastePositive",
   executionSchema: HastePositiveInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitHastePositive,
   discoverCastAct: discoverHastePositiveCastAct,
   resolve: resolveHastePositive,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/held-light-hurl.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/held-light-hurl.ts
@@ -152,7 +152,6 @@ export const heldLightHurlProfile: SpellProcedureDeclaration<
 > = {
   procedure: "heldLightHurl",
   executionSchema: HeldLightHurlInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitHeldLightHurl,
   discoverCastAct: discoverHeldLightHurlCastAct,
   resolve: resolveHeldLightHurl,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/held-light.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/held-light.ts
@@ -372,7 +372,6 @@ export const heldLightProfile: SpellProcedureDeclaration<
 > = {
   procedure: "heldLight",
   executionSchema: HeldLightInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitHeldLight,
   discoverCastAct: discoverHeldLightCastAct,
   resolve: resolveHeldLight,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/hideous-laughter.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/hideous-laughter.ts
@@ -350,7 +350,6 @@ const HideousLaughterInvocationSchema = spellProcedureExecutionSchema(
 export const hideousLaughterProfile = {
   procedure: "hideousLaughter",
   executionSchema: HideousLaughterInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitHideousLaughter,
   discoverCastAct: discoverHideousLaughterCastAct,
   resolve: resolveHideousLaughter,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/hypnotic-pattern.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/hypnotic-pattern.ts
@@ -724,7 +724,6 @@ const HypnoticPatternInvocationSchema = spellProcedureExecutionSchema(
 export const hypnoticPatternProfile = {
   procedure: "hypnoticPattern",
   executionSchema: HypnoticPatternInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitHypnoticPattern,
   discoverCastAct: discoverHypnoticPatternCastAct,
   resolve: resolveHypnoticPattern,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/insect-plague-area-hazard.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/insect-plague-area-hazard.ts
@@ -284,7 +284,6 @@ const InsectPlagueAreaHazardInvocationSchema = spellProcedureExecutionSchema(
 export const insectPlagueAreaHazardProfile = {
   procedure: "insectPlagueAreaHazard",
   executionSchema: InsectPlagueAreaHazardInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitInsectPlagueAreaHazard,
   discoverCastAct: discoverInsectPlagueAreaHazardCastAct,
   resolve: resolveInsectPlagueAreaHazard,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/jump-movement-replacement.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/jump-movement-replacement.ts
@@ -359,7 +359,6 @@ const JumpMovementReplacementInvocationSchema = spellProcedureExecutionSchema(
 export const jumpMovementReplacementProfile = {
   procedure: "jumpMovementReplacement",
   executionSchema: JumpMovementReplacementInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitJumpMovementReplacement,
   discoverCastAct: discoverJumpMovementReplacementCastAct,
   resolve: resolveJumpMovementReplacement,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/levitated-creature.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/levitated-creature.ts
@@ -503,7 +503,6 @@ export const levitatedCreatureProfile: SpellProcedureDeclaration<
 > = {
   procedure: "levitatedCreature",
   executionSchema: LevitatedCreatureInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitLevitatedCreature,
   discoverCastAct: discoverLevitatedCreatureCastAct,
   resolve: resolveLevitatedCreature,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/magic-weapon-enhancement.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/magic-weapon-enhancement.ts
@@ -423,7 +423,6 @@ export const magicWeaponEnhancementProfile: SpellProcedureDeclaration<
 > = {
   procedure: "magicWeaponEnhancement",
   executionSchema: MagicWeaponEnhancementInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitMagicWeaponEnhancement,
   discoverCastAct: discoverMagicWeaponEnhancementCastAct,
   resolve: resolveMagicWeaponEnhancement,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/magical-darkness-point-origin.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/magical-darkness-point-origin.ts
@@ -220,7 +220,6 @@ const MagicalDarknessPointOriginInvocationSchema =
 export const magicalDarknessPointOriginProfile = {
   procedure: "magicalDarknessPointOrigin",
   executionSchema: MagicalDarknessPointOriginInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitMagicalDarknessPointOrigin,
   discoverCastAct: discoverMagicalDarknessPointOriginCastAct,
   resolve: resolveMagicalDarknessPointOrigin,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/make-stable.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/make-stable.ts
@@ -272,7 +272,6 @@ export const makeStableProfile: SpellProcedureDeclaration<
 > = {
   procedure: "makeStable",
   executionSchema: MakeStableInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitMakeStable,
   discoverCastAct: discoverMakeStableCastAct,
   resolve: resolveMakeStable,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/marked-damage-rider.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/marked-damage-rider.ts
@@ -878,7 +878,6 @@ export const markedDamageRiderProfile: SpellProcedureDeclaration<
 > = {
   procedure: "markedDamageRider",
   executionSchema: MarkedDamageRiderInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitMarkedDamageRider,
   discoverCastAct: discoverMarkedDamageRiderCastAct,
   resolve: resolveMarkedDamageRider,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/mirror-image-hit-interception.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/mirror-image-hit-interception.ts
@@ -291,7 +291,6 @@ export const mirrorImageHitInterceptionProfile: SpellProcedureDeclaration<
 > = {
   procedure: "mirrorImageHitInterception",
   executionSchema: MirrorImageHitInterceptionInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitMirrorImageHitInterception,
   discoverCastAct: discoverMirrorImageHitInterceptionCastAct,
   resolve: resolveMirrorImageHitInterception,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/moonbeam.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/moonbeam.ts
@@ -338,7 +338,6 @@ const MoonbeamInvocationSchema = spellProcedureExecutionSchema(
 export const moonbeamProfile = {
   procedure: "moonbeam",
   executionSchema: MoonbeamInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitMoonbeam,
   discoverCastAct: discoverMoonbeamCastAct,
   resolve: resolveMoonbeam,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/object-contact-damage.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/object-contact-damage.ts
@@ -509,7 +509,6 @@ export const objectContactDamageProfile: SpellProcedureDeclaration<
 > = {
   procedure: "objectContactDamage",
   executionSchema: ObjectContactDamageInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitObjectContactDamage,
   discoverCastAct: discoverObjectContactDamageCastAct,
   resolve: resolveObjectContactDamage,
@@ -521,7 +520,6 @@ export const objectContactDamageRepeatProfile: SpellProcedureDeclaration<
 > = {
   procedure: "objectContactDamageRepeat",
   executionSchema: ObjectContactDamageRepeatInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitObjectContactDamageRepeat,
   discoverCastAct: discoverObjectContactDamageRepeatCastAct,
   resolve: resolveObjectContactDamageRepeat,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/object-light.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/object-light.ts
@@ -562,7 +562,6 @@ export const objectLightProfile: SpellProcedureDeclaration<
 > = {
   procedure: "objectLight",
   executionSchema: ObjectLightInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitObjectLight,
   discoverCastAct: discoverObjectLightCastAct,
   resolve: resolveObjectLight,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/ongoing-spell-end.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/ongoing-spell-end.ts
@@ -870,7 +870,6 @@ const OngoingSpellEndInvocationSchema = spellProcedureExecutionSchema(
 export const ongoingSpellEndProfile = {
   procedure: "ongoingSpellEnd",
   executionSchema: OngoingSpellEndInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitOngoingSpellEnd,
   discoverCastAct: discoverOngoingSpellEndCastAct,
   resolve: resolveOngoingSpellEndSpellAct,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/persistent-armor-effect.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/persistent-armor-effect.ts
@@ -333,7 +333,6 @@ export const persistentArmorEffectProfile: SpellProcedureDeclaration<
 > = {
   procedure: "persistentArmorEffect",
   executionSchema: PersistentArmorEffectInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitPersistentArmorEffect,
   discoverCastAct: discoverPersistentArmorEffectCastAct,
   resolve: resolvePersistentArmorEffect,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/registry.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/registry.ts
@@ -134,7 +134,6 @@ function registeredSpellProcedureDeclaration<
     admission: { admit: declaration.admit },
     execution: {
       procedure: declaration.procedure,
-      metamagicCompatibility: declaration.metamagicCompatibility,
       discoverCastAct: declaration.discoverCastAct,
       executionSchema: declaration.executionSchema,
       resolve: declaration.resolve,
@@ -377,7 +376,6 @@ function registeredSpellProcedureExecution<P extends RegisteredSpellProcedure>(
 ): RegisteredSpellProcedureExecution<P> {
   return {
     procedure: declaration.procedure,
-    metamagicCompatibility: declaration.metamagicCompatibility,
     executionSchema: declaration.executionSchema,
     discoverCastAct: declaration.discoverCastAct,
     resolve: (resolution) => {

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/repeated-damage-allocation.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/repeated-damage-allocation.ts
@@ -185,7 +185,6 @@ export const repeatedDamageAllocationProfile: SpellProcedureDeclaration<
 > = {
   procedure: "repeatedDamageAllocation",
   executionSchema: RepeatedDamageAllocationInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitRepeatedDamageAllocation,
   discoverCastAct: discoverRepeatedDamageAllocationCastAct,
   resolve: resolveRepeatedDamageAllocation,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/resolution-contract.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/resolution-contract.ts
@@ -13,7 +13,15 @@ import type {
 import type { BattleInterruptTrigger } from "../../battle-interrupt-triggers.ts";
 import type { BattleSubject } from "../../battle-subjects.ts";
 import type { CharacterBattleMetamagicOptionFact } from "../../character-battle-resource-execution.ts";
-import type { SpellExecutionClassForProcedure } from "../spell-execution-facts.ts";
+import type {
+  SpellExecutionClassForProcedure,
+  SpellProcedureActionCost,
+  SpellProcedureAcceptingActionCostOverride,
+  SpellProcedureAcceptingMetamagicApplications,
+  SpellProcedureExecutionsWithActionCost,
+  SpellProcedureExecutionsWithoutActionCost,
+  SpellProcedureWithQuickenedActionCostRewrite,
+} from "../spell-execution-facts.ts";
 import type {
   BattleSpellProcedureExecution,
   SpellProcedureExecutionByProcedure,
@@ -82,102 +90,24 @@ type TriggeredReactionSpellResolutionInput = BattleResolutionInputForSubject<
   readonly frame: BattleInterruptCheckpoint;
 };
 
-export const ACTION_OR_BONUS_ACTION_SPELL_RESOLUTION_PROCEDURES = [
-  "rollModifier",
-  "directCondition",
-  "creatureSizeIncrease",
-  "creatureSizeDecrease",
-  "scalarBuff",
-  "directHitPointRestoration",
-  "saveGatedDamage",
-  "saveGatedCondition",
-  "saveGatedConditionImmunity",
-  "spellAttackDamage",
-  "spellAttackSequence",
-] as const satisfies ReadonlyArray<SpellProcedureKey>;
+type SpellProcedureActionCostResolutionInput<P extends SpellProcedureKey> = [
+  Exclude<SpellProcedureActionCost<P>, "magicAction" | "bonusAction">,
+] extends [never]
+  ?
+      | ([Extract<SpellProcedureActionCost<P>, "magicAction">] extends [never]
+          ? never
+          : ActionSpellBattleResolutionInput)
+      | ([Extract<SpellProcedureActionCost<P>, "bonusAction">] extends [never]
+          ? never
+          : BonusActionSpellBattleResolutionInput)
+  : never;
 
-export const BONUS_ACTION_ONLY_SPELL_RESOLUTION_PROCEDURES = [
-  "heldLight",
-  "magicWeaponEnhancement",
-  "directConditionRemoval",
-  "jumpMovementReplacement",
-  "selfTeleport",
-  "dragonsBreathInitial",
-  "sanctuaryTargetingInterdiction",
-  "markedDamageRider",
-  "weaponDamageRider",
-  "weaponAttackOverride",
-  "spellCreatedHeldObject",
-  "spellCreatedHeldObjectReEvoke",
-  "spiritualWeaponAttackProxy",
-  "spiritualWeaponRepeatAttack",
-  "objectContactDamageRepeat",
-  "dancingLightsReposition",
-] as const satisfies ReadonlyArray<SpellProcedureKey>;
-
-export const ACTION_SPELL_RESOLUTION_INCOMPATIBLE_PROCEDURES = [
-  ...BONUS_ACTION_ONLY_SPELL_RESOLUTION_PROCEDURES,
-  "expeditiousRetreatDash",
-  "featherFallMitigation",
-  "afterHitDamage",
-  "afterHitSaveGatedCondition",
-  "afterHitTimedDamageAndSave",
-  "afterHitDamageAndIllumination",
-  "counterspell",
-  "shieldReaction",
-] as const satisfies ReadonlyArray<SpellProcedureKey>;
-
-type ActionOrBonusActionProcedure =
-  (typeof ACTION_OR_BONUS_ACTION_SPELL_RESOLUTION_PROCEDURES)[number];
-type BonusActionProcedure =
-  (typeof BONUS_ACTION_ONLY_SPELL_RESOLUTION_PROCEDURES)[number];
-const ACTION_COST_OVERRIDE_PROCEDURES = [
-  "attackBurstSaveDamage",
-  "chainedSpellAttackDamage",
-  "creatureSizeIncrease",
-  "creatureSizeDecrease",
-  "directCondition",
-  "directHitPointRestoration",
-  "heldLightHurl",
-  "rollModifier",
-  "saveGatedCondition",
-  "saveGatedConditionImmunity",
-  "saveGatedDamage",
-  "scalarBuff",
-  "spellAttackDamage",
-  "spellAttackSequence",
-  "spellCreatedHeldObjectAttack",
-] as const satisfies ReadonlyArray<SpellProcedureKey>;
-
-const METAMAGIC_APPLICATION_PROCEDURES = [
-  ...ACTION_COST_OVERRIDE_PROCEDURES,
-  "command",
-  "greaseGroundHazard",
-  "gustOfWindLine",
-  "hideousLaughter",
-  "objectLight",
-  "saveGatedAttackRollAdvantage",
-  "slowActivePenalties",
-] as const satisfies ReadonlyArray<SpellProcedureKey>;
-
-const STORED_GLYPH_RELEASE_PROCEDURES = [
-  "conditionImmunityAndTurnStartTemporaryHitPoints",
-  "creatureSizeIncrease",
-  "creatureSizeDecrease",
-  "creatureTypeProtection",
-  "directCondition",
-  "hastePositive",
-  "levitatedCreature",
-  "rollModifier",
-  "scalarBuff",
-] as const satisfies ReadonlyArray<SpellProcedureKey>;
-
-type ActionCostOverrideProcedure =
-  (typeof ACTION_COST_OVERRIDE_PROCEDURES)[number];
-type MetamagicApplicationProcedure =
-  (typeof METAMAGIC_APPLICATION_PROCEDURES)[number];
-type StoredGlyphReleaseProcedure =
-  (typeof STORED_GLYPH_RELEASE_PROCEDURES)[number];
+type SpellProcedureExecutionClassResolutionInput<P extends SpellProcedureKey> =
+  SpellExecutionClassForProcedure<P> extends "bonusActionCast"
+    ? BonusActionSpellBattleResolutionInput
+    : SpellExecutionClassForProcedure<P> extends "actionCast" | "actionCostCast"
+      ? ActionSpellBattleResolutionInput
+      : never;
 
 export type HypnoticPatternStoredGlyphRelease = {
   readonly kind: "storedGlyphSpellRelease";
@@ -185,14 +115,14 @@ export type HypnoticPatternStoredGlyphRelease = {
 };
 
 type OrdinarySpellProcedureResolutionOptions<P extends SpellProcedureKey> =
-  (P extends ActionCostOverrideProcedure
+  (P extends SpellProcedureAcceptingActionCostOverride
     ? { readonly actionCostOverride?: "magicAction" | "bonusAction" }
-    : object) &
-    (P extends MetamagicApplicationProcedure
+    : { readonly actionCostOverride?: never }) &
+    (P extends SpellProcedureAcceptingMetamagicApplications
       ? {
           readonly metamagicApplications: readonly SpellMetamagicApplicationFact[];
         }
-      : object);
+      : { readonly metamagicApplications?: never });
 
 type SpellProcedureResolutionOptions<P extends SpellProcedureKey> =
   P extends "hypnoticPattern"
@@ -205,7 +135,7 @@ type SpellProcedureResolutionOptions<P extends SpellProcedureKey> =
             readonly metamagicApplications?: never;
             readonly storedGlyphRelease: HypnoticPatternStoredGlyphRelease;
           }
-    : P extends StoredGlyphReleaseProcedure
+    : P extends GlyphStoredSingleCreatureActiveEffectProcedure
       ?
           | (OrdinarySpellProcedureResolutionOptions<P> & {
               readonly storedGlyphRelease?: never;
@@ -233,19 +163,19 @@ export type SpellProcedureResolutionInput<P extends SpellProcedureKey> =
           ? AttackHitSaveGatedConditionResolutionInput
           : P extends "expeditiousRetreatDash"
             ? BonusActionDashSpellBattleResolutionInput
-            : P extends ActionOrBonusActionProcedure
+            : P extends SpellProcedureWithQuickenedActionCostRewrite
               ?
                   | ActionSpellBattleResolutionInput
                   | BonusActionSpellBattleResolutionInput
-              : P extends BonusActionProcedure
-                ? BonusActionSpellBattleResolutionInput
-                : SpellExecutionClassForProcedure<P> extends "bonusActionCast"
-                  ? BonusActionSpellBattleResolutionInput
-                  : SpellExecutionClassForProcedure<P> extends
-                        | "actionCast"
-                        | "actionCostCast"
-                    ? ActionSpellBattleResolutionInput
-                    : never;
+              : [SpellProcedureExecutionsWithActionCost<P>] extends [never]
+                ? SpellProcedureExecutionClassResolutionInput<P>
+                :
+                    | SpellProcedureActionCostResolutionInput<P>
+                    | ([SpellProcedureExecutionsWithoutActionCost<P>] extends [
+                        never,
+                      ]
+                        ? never
+                        : SpellProcedureExecutionClassResolutionInput<P>);
 
 export type SpellProcedureResolutionFillSet<P extends SpellProcedureKey> =
   P extends "afterHitSaveGatedCondition"

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/roll-modifier.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/roll-modifier.ts
@@ -510,7 +510,6 @@ export const rollModifierProfile: SpellProcedureDeclaration<
   RollModifierInvocation
 > = {
   procedure: "rollModifier",
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitRollModifier,
 
   discoverCastAct: discoverRollModifierCastAct,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/sanctuary-targeting-interdiction.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/sanctuary-targeting-interdiction.ts
@@ -266,7 +266,6 @@ const SanctuaryTargetingInterdictionInvocationSchema =
 export const sanctuaryTargetingInterdictionProfile = {
   procedure: "sanctuaryTargetingInterdiction",
   executionSchema: SanctuaryTargetingInterdictionInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitSanctuaryTargetingInterdiction,
   discoverCastAct: discoverSanctuaryTargetingInterdictionCastAct,
   resolve: resolveSanctuaryTargetingInterdiction,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-attack-roll-advantage.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-attack-roll-advantage.ts
@@ -231,7 +231,6 @@ const SaveGatedAttackRollAdvantageInvocationSchema =
 export const saveGatedAttackRollAdvantageProfile = {
   procedure: "saveGatedAttackRollAdvantage",
   executionSchema: SaveGatedAttackRollAdvantageInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSaveGatedAttackRollAdvantage,
   discoverCastAct: discoverSaveGatedAttackRollAdvantageCastAct,
   resolve: resolveSaveGatedAttackRollAdvantage,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-condition-immunity.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-condition-immunity.ts
@@ -244,7 +244,6 @@ const SaveGatedConditionImmunityInvocationSchema =
 export const saveGatedConditionImmunityProfile = {
   procedure: "saveGatedConditionImmunity",
   executionSchema: SaveGatedConditionImmunityInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitSaveGatedConditionImmunity,
   discoverCastAct: discoverSaveGatedConditionImmunityCastAct,
   resolve: resolveSaveGatedConditionImmunity,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-condition.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-condition.ts
@@ -392,7 +392,6 @@ const SaveGatedConditionInvocationSchema = spellProcedureExecutionSchema(
 export const saveGatedConditionProfile = {
   procedure: "saveGatedCondition",
   executionSchema: SaveGatedConditionInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitSaveGatedCondition,
   discoverCastAct: discoverSaveGatedConditionCastAct,
   resolve: resolveSaveGatedCondition,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-damage.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/save-gated-damage.ts
@@ -466,7 +466,6 @@ const SaveGatedDamageInvocationSchema = spellProcedureExecutionSchema(
 export const saveGatedDamageProfile = {
   procedure: "saveGatedDamage",
   executionSchema: SaveGatedDamageInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitSaveGatedDamage,
   discoverCastAct: discoverSaveGatedDamageCastAct,
   resolve: resolveSaveGatedDamage,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/scalar-buff.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/scalar-buff.ts
@@ -579,7 +579,6 @@ const ScalarBuffInvocationSchema = spellProcedureExecutionSchema(
 export const scalarBuffProfile = {
   procedure: "scalarBuff",
   executionSchema: ScalarBuffInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitScalarBuff,
   discoverCastAct: discoverScalarBuffCastAct,
   resolve: resolveScalarBuff,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/see-invisible-observer-sight.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/see-invisible-observer-sight.ts
@@ -274,7 +274,6 @@ export const seeInvisibleObserverSightProfile: SpellProcedureDeclaration<
 > = {
   procedure: "seeInvisibleObserverSight",
   executionSchema: SeeInvisibleObserverSightInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSeeInvisibleObserverSight,
   discoverCastAct: discoverSeeInvisibleObserverSightCastAct,
   resolve: resolveSeeInvisibleObserverSight,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/self-teleport.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/self-teleport.ts
@@ -295,7 +295,6 @@ const SelfTeleportInvocationSchema = spellProcedureExecutionSchema(
 export const selfTeleportProfile = {
   procedure: "selfTeleport",
   executionSchema: SelfTeleportInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitSelfTeleport,
   discoverCastAct: discoverSelfTeleportCastAct,
   resolve: resolveSelfTeleport,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/self-transformation-mode.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/self-transformation-mode.ts
@@ -628,7 +628,6 @@ export const SelfTransformationModeInvocationSchema =
 export const selfTransformationModeProfile = {
   procedure: "selfTransformationMode",
   executionSchema: SelfTransformationModeInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSelfTransformationMode,
   discoverCastAct: discoverSelfTransformationModeCastAct,
   resolve: resolveSelfTransformationMode,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/shield-reaction.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/shield-reaction.ts
@@ -220,7 +220,6 @@ const ShieldReactionInvocationSchema = spellProcedureExecutionSchema(
 export const shieldReactionProfile = {
   procedure: "shieldReaction",
   executionSchema: ShieldReactionInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitShieldReaction,
   discoverCastAct: discoverShieldReactionCastAct,
   resolve: resolveShieldReaction,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/sleep-target-admission.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/sleep-target-admission.ts
@@ -259,7 +259,6 @@ const SleepTargetAdmissionInvocationSchema = spellProcedureExecutionSchema(
 export const sleepTargetAdmissionProfile = {
   procedure: "sleepTargetAdmission",
   executionSchema: SleepTargetAdmissionInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSleepTargetAdmission,
   discoverCastAct: discoverSleepTargetAdmissionCastAct,
   resolve: resolveSleepTargetAdmission,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/sleet-storm-area-hazard.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/sleet-storm-area-hazard.ts
@@ -292,7 +292,6 @@ const SleetStormAreaHazardInvocationSchema = spellProcedureExecutionSchema(
 export const sleetStormAreaHazardProfile = {
   procedure: "sleetStormAreaHazard",
   executionSchema: SleetStormAreaHazardInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSleetStormAreaHazard,
   discoverCastAct: discoverSleetStormAreaHazardCastAct,
   resolve: resolveSleetStormAreaHazard,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/slow-active-penalties.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/slow-active-penalties.ts
@@ -660,7 +660,6 @@ const SlowActivePenaltiesInvocationSchema = spellProcedureExecutionSchema(
 export const slowActivePenaltiesProfile = {
   procedure: "slowActivePenalties",
   executionSchema: SlowActivePenaltiesInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSlowActivePenalties,
   discoverCastAct: discoverSlowActivePenaltiesCastAct,
   resolve: resolveSlowActivePenalties,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-attack-damage.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-attack-damage.ts
@@ -225,7 +225,6 @@ export const spellAttackDamageProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spellAttackDamage",
   executionSchema: SpellAttackDamageInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitSpellAttackDamage,
   discoverCastAct: discoverSpellAttackDamageCastAct,
   resolve: resolveSpellAttackDamage,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-attack-sequence.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-attack-sequence.ts
@@ -158,7 +158,6 @@ export const spellAttackSequenceProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spellAttackSequence",
   executionSchema: SpellAttackSequenceInvocationSchema,
-  metamagicCompatibility: "bonusActionRewrite",
   admit: admitSpellAttackSequence,
   discoverCastAct: discoverSpellAttackSequenceCastAct,
   resolve: resolveSpellAttackSequence,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-created-held-object.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-created-held-object.ts
@@ -803,7 +803,6 @@ export const spellCreatedHeldObjectProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spellCreatedHeldObject",
   executionSchema: SpellCreatedHeldObjectInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitSpellCreatedHeldObject,
   discoverCastAct: discoverSpellCreatedHeldObjectCastAct,
   resolve: resolveSpellCreatedHeldObject,
@@ -815,7 +814,6 @@ export const spellCreatedHeldObjectAttackProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spellCreatedHeldObjectAttack",
   executionSchema: SpellCreatedHeldObjectAttackInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitSpellCreatedHeldObjectAttack,
   discoverCastAct: discoverSpellCreatedHeldObjectAttackCastAct,
   resolve: resolveSpellCreatedHeldObjectAttack,
@@ -827,7 +825,6 @@ export const spellCreatedHeldObjectReEvokeProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spellCreatedHeldObjectReEvoke",
   executionSchema: SpellCreatedHeldObjectReEvokeInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitSpellCreatedHeldObjectReEvoke,
   discoverCastAct: discoverSpellCreatedHeldObjectReEvokeCastAct,
   resolve: resolveSpellCreatedHeldObjectReEvoke,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-hosted-weapon-attack.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spell-hosted-weapon-attack.ts
@@ -432,7 +432,6 @@ export const spellHostedWeaponAttackProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spellHostedWeaponAttack",
   executionSchema: SpellHostedWeaponAttackInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSpellHostedWeaponAttack,
   discoverCastAct: discoverSpellHostedWeaponAttackCastAct,
   resolve: resolveSpellHostedWeaponAttack,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spike-growth-movement-hazard.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spike-growth-movement-hazard.ts
@@ -234,7 +234,6 @@ const SpikeGrowthMovementHazardInvocationSchema = spellProcedureExecutionSchema(
 export const spikeGrowthMovementHazardProfile = {
   procedure: "spikeGrowthMovementHazard",
   executionSchema: SpikeGrowthMovementHazardInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSpikeGrowthMovementHazard,
   discoverCastAct: discoverSpikeGrowthMovementHazardCastAct,
   resolve: resolveSpikeGrowthMovementHazard,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spiritual-weapon.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/spiritual-weapon.ts
@@ -518,7 +518,6 @@ export const spiritualWeaponAttackProxyProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spiritualWeaponAttackProxy",
   executionSchema: SpiritualWeaponAttackProxyInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitSpiritualWeaponAttackProxy,
   discoverCastAct: discoverSpiritualWeaponAttackProxyCastAct,
   resolve: resolveSpiritualWeapon,
@@ -530,7 +529,6 @@ export const spiritualWeaponRepeatAttackProfile: SpellProcedureDeclaration<
 > = {
   procedure: "spiritualWeaponRepeatAttack",
   executionSchema: SpiritualWeaponRepeatAttackInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitSpiritualWeaponRepeatAttack,
   discoverCastAct: discoverSpiritualWeaponRepeatAttackCastAct,
   resolve: resolveSpiritualWeapon,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/thaumaturgy-booming-voice.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/thaumaturgy-booming-voice.ts
@@ -284,7 +284,6 @@ export const thaumaturgyBoomingVoiceProfile: SpellProcedureDeclaration<
 > = {
   procedure: "thaumaturgyBoomingVoice",
   executionSchema: ThaumaturgyBoomingVoiceInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitThaumaturgyBoomingVoice,
   discoverCastAct: discoverThaumaturgyBoomingVoiceCastAct,
   resolve: resolveThaumaturgyBoomingVoice,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/warding-bond.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/warding-bond.ts
@@ -421,7 +421,6 @@ export const wardingBondProfile: SpellProcedureDeclaration<
 > = {
   procedure: "wardingBond",
   executionSchema: WardingBondInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitWardingBond,
   discoverCastAct: discoverWardingBondCastAct,
   resolve: resolveWardingBond,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-attack-override.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-attack-override.ts
@@ -105,7 +105,6 @@ function resolveWeaponAttackOverrideProfile(
 export const weaponAttackOverrideProfile: WeaponAttackOverrideProfile = {
   procedure: "weaponAttackOverride",
   executionSchema: WeaponAttackOverrideExecutionSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: (spell, ctx) =>
     admitWeaponAttackOverride(spell, {
       actor: ctx.actor,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-damage-rider.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/weapon-damage-rider.ts
@@ -269,7 +269,6 @@ export const weaponDamageRiderProfile: SpellProcedureDeclaration<
 > = {
   procedure: "weaponDamageRider",
   executionSchema: WeaponDamageRiderInvocationSchema,
-  metamagicCompatibility: "notActionSpellCasting",
   admit: admitWeaponDamageRider,
   discoverCastAct: discoverWeaponDamageRiderCastAct,
   resolve: resolveWeaponDamageRider,

--- a/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/web-restraint-hazard.ts
+++ b/packages/battle-runtime/src/battle-reducer/spell-procedure-profiles/web-restraint-hazard.ts
@@ -285,7 +285,6 @@ const WebRestraintHazardInvocationSchema = spellProcedureExecutionSchema(
 export const webRestraintHazardProfile = {
   procedure: "webRestraintHazard",
   executionSchema: WebRestraintHazardInvocationSchema,
-  metamagicCompatibility: "actionSpellResolverNotRewritten",
   admit: admitWebRestraintHazard,
   discoverCastAct: discoverWebRestraintHazardCastAct,
   resolve: resolveWebRestraintHazard,

--- a/packages/battle-runtime/src/battle-reducer/spells-discovery.ts
+++ b/packages/battle-runtime/src/battle-reducer/spells-discovery.ts
@@ -286,19 +286,13 @@ export function discoverSupportedSpellInvocations(
         executionInvocation,
       );
       const quickenedTurnResourceAvailable =
-        spellInvocationSupportsQuickenedActionRewrite(
-          executionInvocation,
-          executionRegistry,
-        ) &&
-        actorCanOfferQuickenedSpellMetamagic(
-          {
-            state,
-            actor,
-            actorId,
-            invocation: executionInvocation,
-          },
-          executionRegistry,
-        );
+        spellInvocationSupportsQuickenedActionRewrite(executionInvocation) &&
+        actorCanOfferQuickenedSpellMetamagic({
+          state,
+          actor,
+          actorId,
+          invocation: executionInvocation,
+        });
       if (!naturalTurnResourceAvailable && !quickenedTurnResourceAvailable) {
         return [];
       }
@@ -340,7 +334,6 @@ export function discoverSupportedSpellInvocations(
     )
     .map((act) =>
       spellCastReactionFactsAct(
-        executionRegistry,
         state,
         actor,
         actorId,
@@ -380,19 +373,13 @@ function spellActWithQuickenedRewrite(input: {
     return naturalActs;
   }
   const quickenedActs =
-    spellInvocationSupportsQuickenedActionRewrite(
+    spellInvocationSupportsQuickenedActionRewrite(invocation) &&
+    actorCanOfferQuickenedSpellMetamagic({
+      state: input.state,
+      actor: input.actor,
+      actorId: input.actorId,
       invocation,
-      input.executionRegistry,
-    ) &&
-    actorCanOfferQuickenedSpellMetamagic(
-      {
-        state: input.state,
-        actor: input.actor,
-        actorId: input.actorId,
-        invocation,
-      },
-      input.executionRegistry,
-    )
+    })
       ? [
           {
             ...input.act,
@@ -500,7 +487,6 @@ function spellActWithTwinnedTargetCount(input: {
 }
 
 function spellCastReactionFactsAct(
-  executionRegistry: SpellProcedureExecutionRegistry,
   state: BattleState,
   actor: BattleCreatureState,
   actorId: CombatantId,
@@ -525,7 +511,6 @@ function spellCastReactionFactsAct(
     : {
         ...act,
         initialHoles: spellCastInitialHoles(
-          executionRegistry,
           state,
           actor,
           subject,
@@ -538,7 +523,6 @@ function spellCastReactionFactsAct(
 }
 
 function spellCastInitialHoles(
-  executionRegistry: SpellProcedureExecutionRegistry,
   state: BattleState,
   actor: BattleCreatureState,
   subject: Extract<
@@ -554,16 +538,13 @@ function spellCastInitialHoles(
 ): readonly BattleHole[] {
   const metamagicApplications =
     subject.tag === "actionSpell" || subject.tag === "bonusActionSpell"
-      ? admittedSpellMetamagicApplications(
-          {
-            state,
-            actor,
-            actorId,
-            invocation,
-            subject,
-          },
-          executionRegistry,
-        )
+      ? admittedSpellMetamagicApplications({
+          state,
+          actor,
+          actorId,
+          invocation,
+          subject,
+        })
       : [];
   const slowHole = slowSomaticSpellFailureOutcomeHole({
     state,
@@ -585,20 +566,17 @@ function spellCastInitialHoles(
   ];
 }
 
-function admittedSpellMetamagicApplications(
-  input: {
-    readonly state: BattleState;
-    readonly actor: BattleCreatureState;
-    readonly actorId: CombatantId;
-    readonly invocation: BattleExecutableSpellInvocation;
-    readonly subject: Extract<
-      CharacterProcedureBattleSubject,
-      { readonly tag: "actionSpell" | "bonusActionSpell" }
-    >;
-  },
-  executionRegistry: SpellProcedureExecutionRegistry,
-) {
-  const admission = admitSpellMetamagicApplications(input, executionRegistry);
+function admittedSpellMetamagicApplications(input: {
+  readonly state: BattleState;
+  readonly actor: BattleCreatureState;
+  readonly actorId: CombatantId;
+  readonly invocation: BattleExecutableSpellInvocation;
+  readonly subject: Extract<
+    CharacterProcedureBattleSubject,
+    { readonly tag: "actionSpell" | "bonusActionSpell" }
+  >;
+}) {
+  const admission = admitSpellMetamagicApplications(input);
   return admission.tag === "ok" ? admission.applications : [];
 }
 

--- a/packages/battle-runtime/src/battle-reducer/spells-resolve.ts
+++ b/packages/battle-runtime/src/battle-reducer/spells-resolve.ts
@@ -128,16 +128,20 @@ import { invalidResult } from "./result-helpers.ts";
 import { mirrorImageHitInterceptionCheck } from "./mirror-image-hit-interception.ts";
 import { resolveRemarkableAthleteCriticalHitMovement } from "./remarkable-athlete-critical-movement.ts";
 import {
-  spellProcedureExecutionFor,
   type RegisteredSpellProcedure,
   type RegisteredSpellProcedureExecution,
   type SpellProcedureExecutionRegistry,
 } from "./spell-procedure-profiles/execution-registry.ts";
+import type { SpellProcedureResolutionInput } from "./spell-procedure-profiles/resolution-contract.ts";
 import {
-  ACTION_OR_BONUS_ACTION_SPELL_RESOLUTION_PROCEDURES,
-  ACTION_SPELL_RESOLUTION_INCOMPATIBLE_PROCEDURES,
-  BONUS_ACTION_ONLY_SPELL_RESOLUTION_PROCEDURES,
-} from "./spell-procedure-profiles/resolution-contract.ts";
+  spellExecutionFacts,
+  spellProcedureAcceptsActionCostOverride,
+  spellProcedureAcceptsMetamagicApplications,
+  spellProcedureHasQuickenedActionCostRewrite,
+  spellProcedureSharedSpellAttackDamageBodyRouting,
+  type SpellProcedureAcceptingActionCostOverride,
+  type SpellProcedureWithProfileDelegatedSpellAttackDamageBody,
+} from "./spell-execution-facts.ts";
 import { isTriggeredReactionSpellInvocation } from "./spell-interrupt-procedure-kinds.ts";
 import {
   applySpiritualWeaponAttackProxyEffect,
@@ -300,17 +304,29 @@ import { resolveReadySpellAct } from "./spells-resolve-release.ts";
 import type { SpellProcedureProfileResolveInput } from "./spell-procedure-profiles/execution-profile.ts";
 import { clearPendingAttackRollMissToHitReplacementSelection } from "./statblock-attacks.ts";
 
-type SpellAttackDamageInvocation = Extract<
+type ProfileDelegatedSpellAttackDamageInvocation = Extract<
   SupportedSpellInvocation,
-  { readonly procedure: "spellAttackDamage" }
+  {
+    readonly procedure: SpellProcedureWithProfileDelegatedSpellAttackDamageBody;
+  }
 >;
 
-type ResolveSpellActInternalOptions = {
-  readonly allowBonusActionInvocation?: boolean;
-  readonly useSharedSpellAttackDamageResolver?: true;
-  readonly actionCostOverride?: SpellProcedureActionCostOverride;
-  readonly metamagicApplications?: readonly SpellMetamagicApplicationFact[];
-};
+type ResolveSpellActInternalOptions =
+  | {
+      readonly kind: "registeredProcedure";
+      readonly actionCostOverride?: never;
+      readonly metamagicApplications?: never;
+    }
+  | {
+      readonly kind: "sharedSpellAttackDamage";
+      readonly actionCostOverride?: SpellProcedureActionCostOverride;
+      readonly metamagicApplications?: readonly SpellMetamagicApplicationFact[];
+    }
+  | {
+      readonly kind: "bonusActionSpellAttackProxy";
+      readonly actionCostOverride?: never;
+      readonly metamagicApplications?: never;
+    };
 
 type SpellActInternalInput =
   | ActionSpellBattleResolutionInput
@@ -372,45 +388,6 @@ function spellProcedureResolveDispatchInput<
   return { procedure, resolution };
 }
 
-const PROFILE_DELEGATED_SPELL_ATTACK_DAMAGE_PROCEDURES = [
-  "spellAttackDamage",
-  "heldLightHurl",
-  "spellCreatedHeldObjectAttack",
-] as const satisfies ReadonlyArray<SupportedSpellInvocation["procedure"]>;
-
-const BONUS_ACTION_SPELL_ATTACK_PROXY_PROCEDURES = [
-  "spiritualWeaponAttackProxy",
-  "spiritualWeaponRepeatAttack",
-] as const satisfies ReadonlyArray<SupportedSpellInvocation["procedure"]>;
-
-const ACTION_SPELL_METAMAGIC_RESOLUTION_PROCEDURES = [
-  "saveGatedDamage",
-  "saveGatedCondition",
-  "saveGatedConditionImmunity",
-  "saveGatedAttackRollAdvantage",
-  "hideousLaughter",
-  "hypnoticPattern",
-  "greaseGroundHazard",
-  "gustOfWindLine",
-  "command",
-  "directHitPointRestoration",
-  "directCondition",
-  "rollModifier",
-  "scalarBuff",
-  "objectLight",
-  "creatureSizeIncrease",
-  "creatureSizeDecrease",
-  "spellAttackDamage",
-  "spellAttackSequence",
-] as const satisfies ReadonlyArray<SupportedSpellInvocation["procedure"]>;
-
-function procedureIsIn(
-  procedure: SupportedSpellInvocation["procedure"],
-  procedures: ReadonlyArray<SupportedSpellInvocation["procedure"]>,
-): boolean {
-  return procedures.includes(procedure);
-}
-
 function resolveRegisteredSpellProcedureExecution(
   executionRegistry: SpellProcedureExecutionRegistry,
   input: SpellProcedureResolveDispatchInput,
@@ -435,22 +412,28 @@ type OrdinaryProfileInvocation = Exclude<
   { readonly procedure: "chainedSpellAttackDamage" }
 >;
 
-const BONUS_ACTION_SPELL_PROFILE_PROCEDURES = [
-  ...ACTION_OR_BONUS_ACTION_SPELL_RESOLUTION_PROCEDURES,
-  ...BONUS_ACTION_ONLY_SPELL_RESOLUTION_PROCEDURES,
-] as const satisfies ReadonlyArray<OrdinaryProfileInvocation["procedure"]>;
+type OrdinaryProfileProcedure = OrdinaryProfileInvocation["procedure"];
 
-type ActionSpellProfileInvocation = Exclude<
-  OrdinaryProfileInvocation,
-  {
-    readonly procedure: (typeof ACTION_SPELL_RESOLUTION_INCOMPATIBLE_PROCEDURES)[number];
-  }
->;
+type ProcedureAcceptingResolutionInput<Input> = {
+  [Procedure in OrdinaryProfileProcedure]: Extract<
+    SpellProcedureResolutionInput<Procedure>,
+    Input
+  > extends never
+    ? never
+    : Procedure;
+}[OrdinaryProfileProcedure];
 
 type BonusActionSpellProfileInvocation = Extract<
   OrdinaryProfileInvocation,
   {
-    readonly procedure: (typeof BONUS_ACTION_SPELL_PROFILE_PROCEDURES)[number];
+    readonly procedure: ProcedureAcceptingResolutionInput<BonusActionSpellBattleResolutionInput>;
+  }
+>;
+
+type ActionSpellProfileInvocation = Extract<
+  OrdinaryProfileInvocation,
+  {
+    readonly procedure: ProcedureAcceptingResolutionInput<ActionSpellBattleResolutionInput>;
   }
 >;
 
@@ -459,25 +442,46 @@ type OrdinaryBonusActionSpellProfileInvocation = Exclude<
   { readonly procedure: "weaponAttackOverride" }
 >;
 
-function invocationProcedureIsIn<
-  Invocation extends BattleSpellProcedureExecution,
-  const Procedures extends ReadonlyArray<
-    BattleSpellProcedureExecution["procedure"]
-  >,
->(
-  invocation: Invocation,
-  procedures: Procedures,
-): invocation is Extract<
-  Invocation,
-  { readonly procedure: Procedures[number] }
-> {
-  return procedures.includes(invocation.procedure);
+function invocationUsesActionSpellProfileResolution(
+  invocation: BattleSpellProcedureExecution,
+): invocation is ActionSpellProfileInvocation {
+  return spellExecutionFacts(invocation).kind === "actionSpell";
+}
+
+function invocationUsesBonusActionSpellProfileResolution(
+  invocation: BattleSpellProcedureExecution,
+): invocation is BonusActionSpellProfileInvocation {
+  return (
+    spellExecutionFacts(invocation).kind === "bonusActionSpell" ||
+    spellProcedureHasQuickenedActionCostRewrite(invocation.procedure)
+  );
 }
 
 type SpellProcedureResolutionOptions = {
   readonly actionCostOverride?: SpellProcedureActionCostOverride;
   readonly metamagicApplications: readonly SpellMetamagicApplicationFact[];
 };
+
+function spellProcedureActionCostResolutionOption(
+  procedure: SpellProcedureAcceptingActionCostOverride,
+  actionCostOverride: SpellProcedureActionCostOverride | undefined,
+): { readonly actionCostOverride?: SpellProcedureActionCostOverride };
+function spellProcedureActionCostResolutionOption(
+  procedure: Exclude<
+    RegisteredSpellProcedure,
+    SpellProcedureAcceptingActionCostOverride
+  >,
+  actionCostOverride: SpellProcedureActionCostOverride | undefined,
+): { readonly actionCostOverride?: never };
+function spellProcedureActionCostResolutionOption(
+  procedure: RegisteredSpellProcedure,
+  actionCostOverride: SpellProcedureActionCostOverride | undefined,
+): { readonly actionCostOverride?: SpellProcedureActionCostOverride } {
+  return actionCostOverride === undefined ||
+    !spellProcedureAcceptsActionCostOverride(procedure)
+    ? {}
+    : { actionCostOverride };
+}
 
 function actionSpellProcedureResolveDispatchInput(
   input: ActionSpellBattleResolutionInput,
@@ -495,9 +499,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       rollModifier: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -505,9 +510,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       makeStable: (value) =>
@@ -516,9 +522,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       heldLightHurl: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -526,9 +533,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       objectLight: (value) =>
@@ -537,9 +545,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       thaumaturgyBoomingVoice: (value) =>
@@ -548,9 +557,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       blurAttackRollDefense: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -558,9 +568,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       seeInvisibleObserverSight: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -568,9 +579,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       mirrorImageHitInterception: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -578,9 +590,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       persistentArmorEffect: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -588,9 +601,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       wardingBond: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -598,9 +612,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       creatureTypeProtection: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -608,9 +623,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       conditionRemovalProtection: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -618,9 +634,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       chosenDamageResistance: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -628,9 +645,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       hastePositive: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -638,9 +656,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       directCondition: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -648,9 +667,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       conditionImmunityAndTurnStartTemporaryHitPoints: (value) =>
@@ -659,9 +679,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       creatureSizeIncrease: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -669,9 +690,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       creatureSizeDecrease: (value) =>
@@ -680,9 +702,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       levitatedCreature: (value) =>
@@ -691,9 +714,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       scalarBuff: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -701,9 +725,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       directHitPointRestoration: (value) =>
@@ -712,9 +737,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       selfTransformationMode: (value) =>
@@ -723,9 +749,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       spellHostedWeaponAttack: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -733,9 +760,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       saveGatedDamage: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -743,9 +771,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       saveGatedCondition: (value) =>
@@ -754,9 +783,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       saveGatedConditionImmunity: (value) =>
@@ -765,9 +795,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       saveGatedAttackRollAdvantage: (value) =>
@@ -776,9 +807,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       abilityD20TestRollModeSaveGate: (value) =>
@@ -787,9 +819,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       sleepTargetAdmission: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -797,9 +830,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       hideousLaughter: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -807,9 +841,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       hypnoticPattern: (value) =>
@@ -818,9 +853,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       slowActivePenalties: (value) =>
@@ -829,9 +865,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       greaseGroundHazard: (value) =>
@@ -840,9 +877,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       gustOfWindLine: (value) =>
@@ -851,9 +889,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       flamingSphere: (value) =>
@@ -862,9 +901,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       moonbeam: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -872,9 +912,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       fogCloudObscurement: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -882,9 +923,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       spikeGrowthMovementHazard: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -892,9 +934,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       webRestraintHazard: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -902,9 +945,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       sleetStormAreaHazard: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -912,9 +956,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       insectPlagueAreaHazard: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -922,9 +967,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       cloudkillAreaHazard: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -932,9 +978,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       magicalDarknessPointOrigin: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -942,9 +989,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       antimagicFieldOngoingSpellSuppression: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -952,9 +1000,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       command: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -962,9 +1011,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       spellAttackDamage: (value) =>
@@ -973,9 +1023,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       spellAttackSequence: (value) =>
@@ -984,9 +1035,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       spellCreatedHeldObjectAttack: (value) =>
@@ -995,9 +1047,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       objectContactDamage: (value) =>
@@ -1006,9 +1059,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       ongoingSpellEnd: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1016,9 +1070,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       attackBurstSaveDamage: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1026,9 +1081,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       repeatedDamageAllocation: (value) =>
@@ -1037,9 +1093,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       dancingLightsSeparateCast: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1047,9 +1104,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       dancingLightsCombinedCast: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1057,9 +1115,10 @@ function actionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
     }),
   );
@@ -1081,9 +1140,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       heldLight: (value) =>
@@ -1092,9 +1152,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       magicWeaponEnhancement: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1102,9 +1163,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       directCondition: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1112,9 +1174,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       creatureSizeIncrease: (value) =>
@@ -1123,9 +1186,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       creatureSizeDecrease: (value) =>
@@ -1134,9 +1198,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       directConditionRemoval: (value) =>
@@ -1145,9 +1210,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       scalarBuff: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1155,9 +1221,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       directHitPointRestoration: (value) =>
@@ -1166,9 +1233,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       jumpMovementReplacement: (value) =>
@@ -1177,9 +1245,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       selfTeleport: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1187,9 +1256,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       dragonsBreathInitial: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1197,9 +1267,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       sanctuaryTargetingInterdiction: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1207,9 +1278,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       markedDamageRider: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1217,9 +1289,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       weaponDamageRider: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1227,9 +1300,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       saveGatedDamage: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1237,9 +1311,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       saveGatedCondition: (value) =>
@@ -1248,9 +1323,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       saveGatedConditionImmunity: (value) =>
@@ -1259,9 +1335,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       spellAttackDamage: (value) =>
@@ -1270,9 +1347,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       spellAttackSequence: (value) =>
@@ -1281,9 +1359,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
           metamagicApplications: resolutionOptions.metamagicApplications,
         }),
       spellCreatedHeldObject: (value) =>
@@ -1292,9 +1371,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       spellCreatedHeldObjectReEvoke: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1302,9 +1382,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       spiritualWeaponAttackProxy: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1312,9 +1393,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       spiritualWeaponRepeatAttack: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1322,9 +1404,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       objectContactDamageRepeat: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1332,9 +1415,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
       dancingLightsReposition: (value) =>
         spellProcedureResolveDispatchInput(value.procedure, {
@@ -1342,9 +1426,10 @@ function bonusActionSpellProcedureResolveDispatchInput(
           actorId,
           invocation: value,
           fillSet,
-          ...(resolutionOptions.actionCostOverride === undefined
-            ? {}
-            : { actionCostOverride: resolutionOptions.actionCostOverride }),
+          ...spellProcedureActionCostResolutionOption(
+            value.procedure,
+            resolutionOptions.actionCostOverride,
+          ),
         }),
     }),
   );
@@ -1354,16 +1439,13 @@ function actionSpellUsesSharedSpellAttackDamageBody(
   invocation: BattleExecutableSpellInvocation,
   options: ResolveSpellActInternalOptions,
 ): boolean {
+  const routing = spellProcedureSharedSpellAttackDamageBodyRouting(
+    invocation.procedure,
+  );
   return (
-    procedureIsIn(
-      invocation.procedure,
-      BONUS_ACTION_SPELL_ATTACK_PROXY_PROCEDURES,
-    ) ||
-    (options.useSharedSpellAttackDamageResolver === true &&
-      procedureIsIn(
-        invocation.procedure,
-        PROFILE_DELEGATED_SPELL_ATTACK_DAMAGE_PROCEDURES,
-      ))
+    routing === "direct" ||
+    (routing === "profileDelegated" &&
+      options.kind === "sharedSpellAttackDamage")
   );
 }
 
@@ -1569,22 +1651,17 @@ export function resolveSpellAct(
   input: AdmittedActionSpellBattleResolutionInput,
   executionRegistry: SpellProcedureExecutionRegistry,
 ): BattleResolutionResult {
-  return resolveSpellActInternal(input, executionRegistry);
+  return resolveSpellActInternal(input, executionRegistry, {
+    kind: "registeredProcedure",
+  });
 }
 
 export function resolveSpellAttackDamageAct(
-  input: SpellProcedureProfileResolveInput<
-    | SpellAttackDamageInvocation
-    | Extract<SupportedSpellInvocation, { readonly procedure: "heldLightHurl" }>
-    | Extract<
-        SupportedSpellInvocation,
-        { readonly procedure: "spellCreatedHeldObjectAttack" }
-      >
-  >,
+  input: SpellProcedureProfileResolveInput<ProfileDelegatedSpellAttackDamageInvocation>,
   executionRegistry: SpellProcedureExecutionRegistry,
 ): BattleResolutionResult {
   return resolveSpellActInternal(input.input, executionRegistry, {
-    useSharedSpellAttackDamageResolver: true,
+    kind: "sharedSpellAttackDamage",
     ...(input.actionCostOverride === undefined
       ? {}
       : { actionCostOverride: input.actionCostOverride }),
@@ -1597,7 +1674,7 @@ export function resolveSpellAttackDamageAct(
 function resolveSpellActInternal(
   unresolvedInput: SpellActInternalInput,
   executionRegistry: SpellProcedureExecutionRegistry,
-  options: ResolveSpellActInternalOptions = {},
+  options: ResolveSpellActInternalOptions,
 ): BattleResolutionResult {
   const lane = spellActLane(unresolvedInput);
   const input = lane.input;
@@ -1633,7 +1710,7 @@ function resolveSpellActInternal(
   if (
     actor?.origin.kind === "character" &&
     invocation == null &&
-    options.allowBonusActionInvocation === true &&
+    options.kind === "bonusActionSpellAttackProxy" &&
     boundInvocation !== undefined &&
     invocationRefHasAntimagicSuppressedRepeatResolverGuard(
       boundInvocation.procedure,
@@ -1648,16 +1725,13 @@ function resolveSpellActInternal(
       "Action-time spell act requires a supported prepared spell or cantrip.",
     );
   }
-  const metamagicAdmission = admitSpellMetamagicApplications(
-    {
-      state: input.state,
-      actor,
-      actorId: subject.actorId,
-      invocation,
-      subject,
-    },
-    executionRegistry,
-  );
+  const metamagicAdmission = admitSpellMetamagicApplications({
+    state: input.state,
+    actor,
+    actorId: subject.actorId,
+    invocation,
+    subject,
+  });
   if (metamagicAdmission.tag !== "ok") {
     return invalidResult(
       input.state,
@@ -1792,7 +1866,7 @@ function resolveSpellActInternal(
   if (
     "actionCost" in invocation &&
     invocation.actionCost === "bonusAction" &&
-    options.allowBonusActionInvocation !== true &&
+    options.kind !== "bonusActionSpellAttackProxy" &&
     !(
       lane.tag === "action" &&
       lane.input.replayingInterruptedProcedure === true &&
@@ -1926,12 +2000,7 @@ function resolveSpellActInternal(
         "This spell procedure does not use the Bonus Action spell resolution lane.",
       );
     }
-    if (
-      invocationProcedureIsIn(
-        invocation,
-        ACTION_SPELL_RESOLUTION_INCOMPATIBLE_PROCEDURES,
-      )
-    ) {
+    if (!invocationUsesActionSpellProfileResolution(invocation)) {
       return invalidResult(
         input.state,
         "unsupportedSubject",
@@ -1946,10 +2015,7 @@ function resolveSpellActInternal(
         subject.actorId,
         invocation,
         fillSet,
-        procedureIsIn(
-          invocation.procedure,
-          ACTION_SPELL_METAMAGIC_RESOLUTION_PROCEDURES,
-        )
+        spellProcedureAcceptsMetamagicApplications(invocation.procedure)
           ? { metamagicApplications: metamagicAdmission.applications }
           : { metamagicApplications: [] },
       ),
@@ -1992,12 +2058,10 @@ function resolveSpellActInternal(
     );
   }
   const invocationForResolution = selectedInvocation.invocation;
-  const metamagicApplicationsForResolution = procedureIsIn(
-    invocation.procedure,
-    ACTION_SPELL_METAMAGIC_RESOLUTION_PROCEDURES,
-  )
-    ? metamagicAdmission.applications
-    : options.metamagicApplications;
+  const metamagicApplicationsForResolution =
+    spellProcedureAcceptsMetamagicApplications(invocation.procedure)
+      ? metamagicAdmission.applications
+      : options.metamagicApplications;
   if (
     (invocationForResolution.procedure === "spiritualWeaponAttackProxy" ||
       invocationForResolution.procedure === "spiritualWeaponRepeatAttack") &&
@@ -3990,16 +4054,13 @@ export function resolveBonusActionSpellAct(
       "Bonus Action spell act requires a supported Bonus Action spell.",
     );
   }
-  const metamagicAdmission = admitSpellMetamagicApplications(
-    {
-      state: input.state,
-      actor,
-      actorId: subject.actorId,
-      invocation,
-      subject,
-    },
-    executionRegistry,
-  );
+  const metamagicAdmission = admitSpellMetamagicApplications({
+    state: input.state,
+    actor,
+    actorId: subject.actorId,
+    invocation,
+    subject,
+  });
   if (metamagicAdmission.tag !== "ok") {
     return invalidResult(
       input.state,
@@ -4282,9 +4343,7 @@ export function resolveBonusActionSpellAct(
   if (fillSet.tag === "invalid") {
     return invalidResult(input.state, "invalidFill", fillSet.message);
   }
-  if (
-    !invocationProcedureIsIn(invocation, BONUS_ACTION_SPELL_PROFILE_PROCEDURES)
-  ) {
+  if (!invocationUsesBonusActionSpellProfileResolution(invocation)) {
     return invalidResult(
       input.state,
       "unsupportedSubject",
@@ -4300,11 +4359,11 @@ export function resolveBonusActionSpellAct(
       invocation,
       fillSet,
       {
-        metamagicApplications:
-          spellProcedureExecutionFor(executionRegistry, invocation.procedure)
-            .metamagicCompatibility === "bonusActionRewrite"
-            ? metamagicAdmission.applications
-            : [],
+        metamagicApplications: spellProcedureHasQuickenedActionCostRewrite(
+          invocation.procedure,
+        )
+          ? metamagicAdmission.applications
+          : [],
         ...(actionCostOverride === undefined ? {} : { actionCostOverride }),
       },
     ),
@@ -4324,7 +4383,7 @@ export function resolveBonusActionSpellAttackProxyAct(
       },
     },
     executionRegistry,
-    { allowBonusActionInvocation: true },
+    { kind: "bonusActionSpellAttackProxy" },
   );
   return result.tag === "needsHoles"
     ? {

--- a/packages/battle-runtime/src/battle-runtime-metamagic-resource.test.ts
+++ b/packages/battle-runtime/src/battle-runtime-metamagic-resource.test.ts
@@ -52,7 +52,6 @@ import {
   TWINNED_METAMAGIC_EFFECT_KIND,
   twinnedSpellTargetCountInvocation,
 } from "./battle-reducer/metamagic.ts";
-import { spellProcedureExecutionRegistry } from "./battle-reducer/spell-procedure-profiles/execution-composition.ts";
 import { supportedSpellActs } from "./battle-reducer/spells-profiles.ts";
 import { battleFillEquals } from "./battle-reducer/dispatcher.ts";
 import {
@@ -1322,20 +1321,17 @@ describe("battle runtime: Sorcerer Metamagic cast governor and Quickened Spell",
     const actor = requireBattleCreature(state, wizardId);
 
     expect(
-      admitSpellMetamagicApplications(
-        {
-          state,
-          actor,
-          actorId: wizardId,
-          invocation: healingWord,
-          subject: {
-            tag: "bonusActionSpell",
-            mode: { tag: "cast" },
-            metamagic: [{ effectKind: SUBTLE_METAMAGIC_EFFECT_KIND }],
-          },
+      admitSpellMetamagicApplications({
+        state,
+        actor,
+        actorId: wizardId,
+        invocation: healingWord,
+        subject: {
+          tag: "bonusActionSpell",
+          mode: { tag: "cast" },
+          metamagic: [{ effectKind: SUBTLE_METAMAGIC_EFFECT_KIND }],
         },
-        spellProcedureExecutionRegistry(),
-      ),
+      }),
     ).toEqual({
       tag: "spellMetamagicAdmissionIssue",
       message: "Subtle Spell is supported only for action-time spell casts.",
@@ -3597,20 +3593,17 @@ function admittedSubtleProjection(
   if (invocation.resource.tag !== "spellSlot") {
     throw new Error("Expected Spell Slot invocation.");
   }
-  const admission = admitSpellMetamagicApplications(
-    {
-      state,
-      actor: requireBattleCreature(state, wizardId),
-      actorId: wizardId,
-      invocation,
-      subject: {
-        tag: "actionSpell",
-        mode: { tag: "cast" },
-        metamagic: [{ effectKind: SUBTLE_METAMAGIC_EFFECT_KIND }],
-      },
+  const admission = admitSpellMetamagicApplications({
+    state,
+    actor: requireBattleCreature(state, wizardId),
+    actorId: wizardId,
+    invocation,
+    subject: {
+      tag: "actionSpell",
+      mode: { tag: "cast" },
+      metamagic: [{ effectKind: SUBTLE_METAMAGIC_EFFECT_KIND }],
     },
-    spellProcedureExecutionRegistry(),
-  );
+  });
   if (admission.tag !== "ok") {
     throw new Error(`Expected admitted Subtle Spell: ${admission.message}`);
   }

--- a/packages/battle-runtime/src/sorcerer-metamagic-subtle-selected-identity.mbt.test.ts
+++ b/packages/battle-runtime/src/sorcerer-metamagic-subtle-selected-identity.mbt.test.ts
@@ -20,7 +20,6 @@ import {
   SUBTLE_METAMAGIC_EFFECT_KIND,
   subtleSpellComponentProjectionForApplications,
 } from "./battle-reducer/metamagic.ts";
-import { spellProcedureExecutionRegistry } from "./battle-reducer/spell-procedure-profiles/execution-composition.ts";
 import { supportedSpellActs } from "./battle-reducer/spells-profiles.ts";
 import {
   characterBattleResourceIsPointPool,
@@ -217,16 +216,13 @@ function resolveSubtleFalseLife(): {
   const act = subtleFalseLifeAct(state);
   const subject = act.subject;
   const falseLifeSpell = spellRecord(falseLifeUnitId);
-  const admitted = admitSpellMetamagicApplications(
-    {
-      state: state.state,
-      actor,
-      actorId: spellCasterId,
-      invocation: supportedFalseLifeInvocation(state),
-      subject,
-    },
-    spellProcedureExecutionRegistry(),
-  );
+  const admitted = admitSpellMetamagicApplications({
+    state: state.state,
+    actor,
+    actorId: spellCasterId,
+    invocation: supportedFalseLifeInvocation(state),
+    subject,
+  });
   if (admitted.tag !== "ok") {
     throw new Error(`Expected Subtle Spell admission: ${admitted.message}`);
   }

--- a/packages/battle-runtime/src/unit-profile-admission-dragons-breath.test.ts
+++ b/packages/battle-runtime/src/unit-profile-admission-dragons-breath.test.ts
@@ -5,6 +5,8 @@ import { battleRuntimeSessionForTest } from "./battle-runtime-session.test-suppo
 // KERNEL-COVERAGE: parity-witness BATTLE.SPELL.DRAGONS_BREATH_INITIAL_EFFECT_STATE
 // KERNEL-COVERAGE: parity-witness BATTLE.SPELL.DRAGONS_BREATH_GRANTED_ACTION
 import { battleActSpellPresentation } from "./battle-act-composition.ts";
+import { spellExecutionFacts } from "./battle-reducer/spell-execution-facts.ts";
+import { supportedSpellActs } from "./battle-reducer/spells-profiles.ts";
 import { describe, expect, test } from "vitest";
 import dragonsBreathInput from "../../surface/content/dragons_breath.json";
 import {
@@ -69,14 +71,23 @@ describe("Dragon's Breath initial cast admission", () => {
     });
     const targetHole = requireHole(act.initialHoles, "spellTargetList");
     const damageTypeHole = requireHole(act.initialHoles, "damageTypeChoice");
+    const invocationPresentation = battleActSpellPresentation(act)?.invocation;
+    const invocation = supportedSpellActs(
+      requireCombatant(state, spellCasterId),
+    ).find(
+      (candidate) => candidate.sourceProcedureRef === act.subject.procedureRef,
+    );
     const expectedSpellSaveDc = spellSaveDcForCaster(state, spellCasterId);
     if (expectedSpellSaveDc === null) {
       throw new Error("Expected fixture caster Spell Save DC.");
     }
+    if (invocation === undefined) {
+      throw new Error("Expected Dragon's Breath runtime invocation.");
+    }
 
     expect({
       ...act.subject,
-      invocation: battleActSpellPresentation(act)?.invocation,
+      invocation: invocationPresentation,
     }).toMatchObject({
       tag: "bonusActionSpell",
       actorId: spellCasterId,
@@ -87,6 +98,7 @@ describe("Dragon's Breath initial cast admission", () => {
       ),
       mode: { tag: "cast" },
     });
+    expect(spellExecutionFacts(invocation).kind).toBe("bonusActionSpell");
     expect(damageTypeHole.choices).toEqual([
       "acid",
       "cold",


### PR DESCRIPTION
Closes #223

## What changed

- Centralized explicit spell procedure routing facts in one exhaustive owner.
- Derived resolver capabilities, action lanes, metamagic subsets, stored-glyph support, and spell-attack dispatch from precise execution types and canonical facts.
- Removed synchronized capability arrays and per-profile duplicated execution metadata.
- Corrected Dragon's Breath initial execution classification to its RAW Bonus Action casting time.

## Why

Procedure capabilities were distributed across registries and parallel arrays, creating distant connascence and allowing meaningful subsets to drift. The new mapping makes widening remain correct or fail at the owning type boundary.

## Verification

- Focused contract/metamagic/spell-attack/glyph tests: 132 passed.
- Dragon's Breath focused MBT: 5 passed.
- `pnpm typecheck`
- `pnpm test`
- `pnpm quality`
- Two converged RAW/domain, architecture/connascence, standards, and spec review rounds with no reasonable findings.